### PR TITLE
About License

### DIFF
--- a/BUILD.MD
+++ b/BUILD.MD
@@ -1,0 +1,13 @@
+# Build instructions 
+
+## How to build the software from sources
+
+```
+mvn clean install
+```
+
+## How to build the software for distribution
+
+```
+mvn clean license:download-licenses license:add-third-party install
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/gazeplay-melordi/pom.xml
+++ b/gazeplay-melordi/pom.xml
@@ -66,6 +66,18 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+			<resource>
+				<directory>target/generated-resources</directory>
+			</resource>
+			<resource>
+				<directory>target/generated-sources/license</directory>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/gazeplay-picto-pick/pom.xml
+++ b/gazeplay-picto-pick/pom.xml
@@ -78,6 +78,18 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+			<resource>
+				<directory>target/generated-resources</directory>
+			</resource>
+			<resource>
+				<directory>target/generated-sources/license</directory>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/gazeplay-tobii-setup/pom.xml
+++ b/gazeplay-tobii-setup/pom.xml
@@ -66,6 +66,18 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+			<resource>
+				<directory>target/generated-resources</directory>
+			</resource>
+			<resource>
+				<directory>target/generated-sources/license</directory>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/gazeplay/pom.xml
+++ b/gazeplay/pom.xml
@@ -21,7 +21,7 @@
 			<artifactId>gazeplay-commons</artifactId>
 			<version>1.0.5</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.oracle</groupId>
 			<artifactId>javafx</artifactId>
@@ -78,6 +78,12 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/gazeplay/pom.xml
+++ b/gazeplay/pom.xml
@@ -83,6 +83,12 @@
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
+			<resource>
+				<directory>target/generated-resources</directory>
+			</resource>
+			<resource>
+				<directory>target/generated-sources/license</directory>
+			</resource>
 		</resources>
 		<plugins>
 			<plugin>

--- a/gazeplay/src/license/licenses.xml
+++ b/gazeplay/src/license/licenses.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<licenseSummary xmlns="http://mojo.codehaus.org/"
+				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xsi:schemaLocation="http://mojo.codehaus.org/ licenses.xsd">
+	<dependencies>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<licenses>
+				<license>
+					<name>Apache License 2.0</name>
+					<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+					<distribution>repo</distribution>
+				</license>
+			</licenses>
+		</dependency>
+	</dependencies>
+</licenseSummary>

--- a/gazeplay/src/main/resources/data/common/licence.txt
+++ b/gazeplay/src/main/resources/data/common/licence.txt
@@ -1,6 +1,6 @@
 GAZEPLAY Copyright (C) 2016-2017 Univ. Grenoble Alpes, CNRS, LIG UMR 5217
 
-Version : 1.0.5 (2017-??-??)
+Version : ${project.version} (${maven.build.timestamp})
 
 contact : didier.schwab@univ-grenoble-alpes.fr
 

--- a/gazeplay/src/main/resources/data/common/licence.txt
+++ b/gazeplay/src/main/resources/data/common/licence.txt
@@ -1,6 +1,6 @@
 GAZEPLAY Copyright (C) 2016-2017 Univ. Grenoble Alpes, CNRS, LIG UMR 5217
 
-Version : ${project.version} (${maven.build.timestamp})
+Version : ${project.version} (${build.date})
 
 contact : didier.schwab@univ-grenoble-alpes.fr
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
 	<artifactId>gazeplay-project</artifactId>
 	<packaging>pom</packaging>
 	<version>1.0.5</version>
-	
+
 	<licenses>
 		<license>
 			<name>GNU General Public License (GPL) version 3.0</name>
 			<url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
 		</license>
 	</licenses>
-	
+
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -68,7 +68,7 @@
 				<version>1.2.1</version>
 			</dependency>
 
-			
+
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
@@ -133,6 +133,23 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<configuration>
+					<sortArtifactByName>true</sortArtifactByName>
+					<useMissingFile>true</useMissingFile>
+					<useRepositoryMissingFiles>true</useRepositoryMissingFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<id>download-licenses</id>
+						<goals>
+							<goal>download-licenses</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -174,6 +191,11 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
 					<version>3.0.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>license-maven-plugin</artifactId>
+					<version>1.14</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,14 @@
 	<artifactId>gazeplay-project</artifactId>
 	<packaging>pom</packaging>
 	<version>1.0.5</version>
+	
+	<licenses>
+		<license>
+			<name>GNU General Public License (GPL) version 3.0</name>
+			<url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
+		</license>
+	</licenses>
+	
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,24 @@
 
 	<build>
 		<plugins>
-
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>timestamp-property</id>
+						<goals>
+							<goal>timestamp-property</goal>
+						</goals>
+						<configuration>
+							<name>build.date</name>
+							<pattern>yyyy-MM-dd</pattern>
+							<locale>en_US</locale>
+							<timeZone>UTC</timeZone>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -144,6 +161,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.1.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.0.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
version tag and build date are now included automatically in license.txt file

third parties libraries name and licenses can now be included automatically in generated JAR file. 
According to third parties license terms, the full license text should be provided with the distributed binaries.
