### PR TITLE
only use oraclejdk with TravisCI for the moment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 dist: trusty
-sudo: required
+sudo: false
 language: java
 jdk: openjdk8
 matrix:
   include:
-    - #dist: trusty
+    - dist: trusty
       jdk: oraclejdk8
-    - #dist: trusty
-      jdk: openjdk8
-before_install:
-  - sudo apt-get install -y openjfx
+      sudo: false
+      env: JENV=oraclejdk8
+    #- dist: xenial
+    #  jdk: openjdk8
+    #  sudo: false
+    #  env: JENV=xenial_openjdk8
+    #- dist: trusty
+    #  jdk: openjdk8
+    #  sudo: required
+    #  env: JENV=trusty_openjdk8
+#before_install:
+#  - if [[ "$JENV" == "xenial_openjdk8" ]]; then sudo apt-get update -q && sudo apt-get install openjfx -y            ; fi
 script:
 - mvn clean install -Dfindbugs.skip=false

--- a/gazeplay-commons/pom.xml
+++ b/gazeplay-commons/pom.xml
@@ -16,7 +16,11 @@
 	</parent>
 
 	<dependencies>
-
+		<dependency>
+			<groupId>com.oracle</groupId>
+			<artifactId>javafx</artifactId>
+		</dependency>
+		
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>


### PR DESCRIPTION
Travis CI should work now

I tried to make it work with openjdk8 in TravisCI. But I still fail to get openjfx installed on trusty.
And xenial seem to be just an alias for trusty, so it fails also. That's too bad, because it seems it would work on xenial, as per my test in a xenial docker container.
