### PR TITLE
enforce line ending to LF in .java source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
 						<directory>./gazeplay-melordi/src/main/java</directory>
 						<directory>./gazeplay/src/main/java</directory>
 					</directories>
+					<lineEnding>LF</lineEnding>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
in order to get predicable result when building on Windows