### PR TITLE
print the number of listeners in GazeUtils

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/gaze/GazeUtils.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/gaze/GazeUtils.java
@@ -59,8 +59,12 @@ public class GazeUtils {
     public static void addEventFilter(Node gs) {
 
         gm.addGazeListener(gazeListener);
+        final int listenersCount = gm.getNumGazeListeners();
+        log.info("Gaze Event Filters Count = {}", listenersCount);
 
         nodesEventFilter.add(new GazeInfos(gs));
+        final int nodesEventFilterListSize = nodesEventFilter.size();
+        log.info("nodesEventFilterListSize = {}", nodesEventFilterListSize);
     }
 
     public static void addEventHandler(Node gs) {


### PR DESCRIPTION
highlights potential memory leak in 'Where Is It' games