### PR TITLE
added dll directory to PATH

### DIFF
--- a/gazeplay-dist/src/main/bin/gazeplay.bat
+++ b/gazeplay-dist/src/main/bin/gazeplay.bat
@@ -1,5 +1,6 @@
 @echo on
 
+SET PATH=%PATH%;%LocalAppData%\TobiiStreamEngineForJava\lib\tobii\x64
 
 java -Xms256m -Xmx1g -jar ..\lib\gazeplay-${project.version}.jar
 


### PR DESCRIPTION
this dll directory is created at runtime by coylz/TobiiStreamEngineForJava with a name that is known in advance.

```gazeplay.bat``` that is provided in the dist zip file should add the dll directory to the PATH, in order for it to appear in the ```java.library.path``` system property.
