### PR TITLE
Graphical improvement on game menu

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/Utils.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/Utils.java
@@ -1,6 +1,5 @@
 package net.gazeplay.commons.utils.games;
 
-import javafx.collections.ObservableList;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
@@ -198,32 +197,6 @@ public class Utils {
     public static String getGazePlayFolder() {
 
         return System.getProperties().getProperty("user.home") + FILESEPARATOR + "GazePlay" + FILESEPARATOR;
-    }
-
-    /**
-     * @return styles directory for GazePlay : in the default directory of GazePlay, a folder called styles
-     */
-    public static String getStylesFolder() {
-
-        return getGazePlayFolder() + "styles" + FILESEPARATOR;
-    }
-
-    /**
-     * @return CSS files found in the styles folder
-     */
-    public static void addStylesheets(ObservableList<String> styleSheets) {
-
-        File F = new File(getStylesFolder());
-
-        if (F.exists()) {
-
-            File[] Tfiles = F.listFiles();
-            for (int i = 0; i < Tfiles.length; i++) {
-
-                if (Tfiles[i].toString().endsWith(".css"))
-                    styleSheets.add("file://" + Tfiles[i].toString());
-            }
-        }
     }
 
     /**

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
@@ -1,8 +1,8 @@
 .gameChooserButton {
-    -fx-min-width: 22em;
+    -fx-min-width: 20em;
     -fx-min-height: 5em;
-    -fx-pref-width: 22em;
-    -fx-pref-height: 8em;
+    -fx-pref-width: 20em;
+    -fx-pref-height: 5em;
 }
 
 .gameVariationChooserButton {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 22em;
+    -fx-min-height: 5em;
+    -fx-pref-width: 22em;
+    -fx-pref-height: 8em;
+}
+
 .gameVariationChooserButton {
     -fx-background-insets: 0;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
@@ -1,0 +1,12 @@
+.gameVariationChooserButton {
+    -fx-background-insets: 0;
+}
+
+.gameChooserButtonGameTypeIndicator {
+    -fx-border-insets: 0px;
+    -fx-background-radius: 0px;
+}
+
+.gameChooserButtonTitle {
+    -fx-font-size: 8pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
@@ -1,8 +1,8 @@
 .gameChooserButton {
-    -fx-min-width: 22em;
+    -fx-min-width: 20em;
     -fx-min-height: 5em;
-    -fx-pref-width: 22em;
-    -fx-pref-height: 8em;
+    -fx-pref-width: 20em;
+    -fx-pref-height: 5em;
 }
 
 .gameVariationChooserButton {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 22em;
+    -fx-min-height: 5em;
+    -fx-pref-width: 22em;
+    -fx-pref-height: 8em;
+}
+
 .gameVariationChooserButton {
     -fx-background-insets: 0;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
@@ -1,0 +1,12 @@
+.gameVariationChooserButton {
+    -fx-background-insets: 0;
+}
+
+.gameChooserButtonGameTypeIndicator {
+    -fx-border-insets: 0px;
+    -fx-background-radius: 0px;
+}
+
+.gameChooserButtonTitle {
+    -fx-font-size: 8pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
@@ -2,7 +2,16 @@
     -fx-min-width: 22em;
     -fx-min-height: 5em;
     -fx-pref-width: 22em;
-    -fx-pref-height: 8em;
+    -fx-pref-height: 7em;
+}
+
+.gameVariationChooserButton {
+    -fx-background-insets: 0;
+}
+
+.gameChooserButtonGameTypeIndicator {
+    -fx-border-insets: 0px;
+    -fx-background-radius: 0px;
 }
 
 .gameChooserButtonTitle {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
@@ -1,0 +1,3 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 10pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 22em;
+    -fx-min-height: 5em;
+    -fx-pref-width: 22em;
+    -fx-pref-height: 8em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 10pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 22em;
+    -fx-min-height: 5em;
+    -fx-pref-width: 22em;
+    -fx-pref-height: 8em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 12pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
@@ -1,0 +1,3 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 12pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 18em;
+    -fx-min-height: 4em;
+    -fx-pref-width: 28em;
+    -fx-pref-height: 7em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 12pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
@@ -1,0 +1,3 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 12pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 18em;
+    -fx-min-height: 4em;
+    -fx-pref-width: 32em;
+    -fx-pref-height: 9em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 16pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
@@ -1,0 +1,3 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 16pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
@@ -1,3 +1,10 @@
+.gameChooserButton {
+    -fx-min-width: 18em;
+    -fx-min-height: 4em;
+    -fx-pref-width: 40em;
+    -fx-pref-height: 9em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 20pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
@@ -1,0 +1,3 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 20pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
@@ -1,3 +1,12 @@
+.gameChooserButton {
+    /*-fx-pref-width: 32em;*/
+    /*-fx-pref-height: 10em;*/
+    -fx-min-width: 18em;
+    -fx-min-height: 4em;
+    -fx-pref-width: 44em;
+    -fx-pref-height: 11em;
+}
+
 .gameChooserButtonTitle {
     -fx-font-size: 22pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
@@ -1,0 +1,6 @@
+.gameChooserButtonTitle {
+    -fx-font-size: 22pt;
+}
+.gameChooserButton.variant {
+    -fx-font-size: 22pt;
+}

--- a/gazeplay-data/src/main/resources/data/stylesheets/base.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base.css
@@ -53,23 +53,15 @@
 }
 
 .gameChooserButton {
-    /*-fx-pref-width: 32em;*/
-    /*-fx-pref-height: 10em;*/
-    -fx-min-width: 18em;
-    -fx-min-height: 4em;
-    -fx-pref-width: 44em;
-    -fx-pref-height: 11em;
-    
-    
     -fx-background-radius: 0;
     -fx-background-insets: 0;
-    -fx-border-insets: 10px;
+    -fx-border-insets: 1px;
     -fx-border-image-insets: 10px;
 
     -fx-background-color: rgba(0, 0, 0, 1);
-    -fx-border-width: 0px;
+    -fx-border-width: 1px;
     -fx-border-color: rgba(60, 63, 65, 0.7);
-    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 10, 0, 0, 0);
+    -fx-effect: dropshadow(three-pass-box, rgba(255, 255, 255, 0.8), 10, 0, 0, 0);
 }
 
 .gameChooserButton.variant {
@@ -105,7 +97,7 @@
 }
 
 .scroll-pane > .viewport {
-    -fx-background-color: black;
+    -fx-background-color: #101010;
 }
 
 .scroll-bar:horizontal, .scroll-bar:vertical{

--- a/gazeplay-data/src/main/resources/data/stylesheets/base.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base.css
@@ -57,6 +57,10 @@
     /*-fx-pref-height: 10em;*/
     -fx-min-width: 18em;
     -fx-min-height: 4em;
+    -fx-pref-width: 44em;
+    -fx-pref-height: 11em;
+    
+    
     -fx-background-radius: 0;
     -fx-background-insets: 0;
     -fx-border-insets: 10px;
@@ -94,4 +98,34 @@
     -fx-font-weight: bold;
     -fx-font-smoothing-type: lcd;
     -fx-effect: dropshadow( gaussian , rgba(255,255,255,0.5) , 0,0,0,1 );
+}
+
+.scroll-pane {
+    -fx-background-color: black;
+}
+
+.scroll-pane > .viewport {
+    -fx-background-color: black;
+}
+
+.scroll-bar:horizontal, .scroll-bar:vertical{
+    -fx-background-color:transparent;
+}
+
+.increment-button, .decrement-button {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+}
+
+.scroll-bar:horizontal .track,
+.scroll-bar:vertical .track{
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-background-radius: 0em;
+}
+
+.scroll-bar:horizontal .thumb,
+.scroll-bar:vertical .thumb {
+    -fx-background-color: lightgrey;
+    -fx-background-radius: 5em;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base.css
@@ -58,14 +58,40 @@
     -fx-min-width: 18em;
     -fx-min-height: 4em;
     -fx-background-radius: 0;
-    -fx-background-insets: 8;
+    -fx-background-insets: 0;
+    -fx-border-insets: 10px;
+    -fx-border-image-insets: 10px;
+
+    -fx-background-color: rgba(0, 0, 0, 1);
+    -fx-border-width: 0px;
+    -fx-border-color: rgba(60, 63, 65, 0.7);
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 10, 0, 0, 0);
 }
 
-.gameVariationChooserButton {
+.gameChooserButton.variant {
     -fx-pref-width: 32em;
     -fx-pref-height: 10em;
     -fx-min-width: 18em;
     -fx-min-height: 4em;
-    -fx-background-radius: 0;
-    -fx-background-insets: 6;
+}
+
+.gameChooserButtonThumbnail {
+    -fx-background-color: rgba(0, 0, 0, 1);
+    -fx-background-radius: 8px;
+    -fx-border-color: rgba(60, 63, 65, 0.7);
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 10, 0, 0, 0);
+}
+
+.gameChooserButtonGameTypeIndicator {
+    -fx-background-color: rgba(0, 0, 0, 1);
+    -fx-background-radius: 8px;
+    -fx-border-color: rgba(60, 63, 65, 0.7);
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 10, 0, 0, 0);
+}
+
+.gameChooserButtonTitle {
+    -fx-text-fill: #333333;
+    -fx-font-weight: bold;
+    -fx-font-smoothing-type: lcd;
+    -fx-effect: dropshadow( gaussian , rgba(255,255,255,0.5) , 0,0,0,1 );
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base.css
@@ -64,11 +64,7 @@
     -fx-effect: dropshadow(three-pass-box, rgba(255, 255, 255, 0.8), 10, 0, 0, 0);
 }
 
-.gameChooserButton.variant {
-    -fx-pref-width: 32em;
-    -fx-pref-height: 10em;
-    -fx-min-width: 18em;
-    -fx-min-height: 4em;
+.gameChooserButton.gameVariation {
 }
 
 .gameChooserButtonThumbnail {

--- a/gazeplay/src/main/java/net/gazeplay/GraphicalContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GraphicalContext.java
@@ -12,6 +12,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.paint.Color;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import lombok.Data;
@@ -96,7 +97,16 @@ public abstract class GraphicalContext<T> {
             buttonGraphics = new Image("data/common/images/fullscreen-enter.png");
             label = "Enter FullScreen";
         }
-        button.setGraphic(new ImageView(buttonGraphics));
+        ImageView imageView = new ImageView(buttonGraphics);
+        imageView.setPreserveRatio(true);
+        imageView.setFitWidth(Screen.getPrimary().getBounds().getWidth() / 40);
+        button.heightProperty().addListener(new ChangeListener<Number>() {
+            @Override
+            public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
+                imageView.setFitHeight(newValue.doubleValue() / 2d);
+            }
+        });
+        button.setGraphic(imageView);
         button.setText(label);
     }
 

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -147,6 +147,10 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         FlowPane choicePane = new FlowPane();
         choicePane.setAlignment(Pos.CENTER);
 
+        ScrollPane choicePanelScroller = new ScrollPane(choicePane);
+        choicePanelScroller.setFitToWidth(true);
+        choicePanelScroller.setFitToHeight(true);
+
         for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
             Button button = new Button(variant.getLabel());
             button.getStyleClass().add("gameChooserButton");
@@ -163,7 +167,7 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
             });
         }
 
-        Scene scene = new Scene(choicePane, Color.TRANSPARENT);
+        Scene scene = new Scene(choicePanelScroller, Color.TRANSPARENT);
 
         final Configuration config = ConfigurationBuilder.createFromPropertiesResource().build();
         CssUtil.setPreferredStylesheets(config, scene);

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -20,6 +20,7 @@ import javafx.scene.paint.ImagePattern;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.commons.configuration.Configuration;
@@ -34,8 +35,6 @@ import net.gazeplay.commons.utils.stats.Stats;
 
 import java.util.Collection;
 import java.util.List;
-import javafx.application.Platform;
-import javafx.stage.StageStyle;
 
 @Data
 @Slf4j
@@ -161,7 +160,9 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
 
         for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
             Button button = new Button(variant.getLabel());
-            button.getStyleClass().add("gameVariationChooserButton");
+            button.getStyleClass().add("gameChooserButton");
+            button.getStyleClass().add("variant");
+            button.getStyleClass().add("button");
             choicePane.getChildren().add(button);
 
             button.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
@@ -188,6 +189,8 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
 
         FlowPane choicePanel = new FlowPane();
         choicePanel.setAlignment(Pos.CENTER);
+        choicePanel.setHgap(10);
+        choicePanel.setVgap(10);
 
         Multilinguism multilinguism = Multilinguism.getSingleton();
 
@@ -202,27 +205,30 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
 
             Label text = new Label(gameName);
 
+            text.getStyleClass().add("gameChooserButtonTitle");
+
             if (gameSummary.getGameTypeIndicatorImageLocation() != null) {
                 Image buttonGraphics = new Image(gameSummary.getGameTypeIndicatorImageLocation());
                 ImageView imageView = new ImageView(buttonGraphics);
+                imageView.getStyleClass().add("gameChooserButtonGameTypeIndicator");
                 imageView.setFitWidth(32);
                 imageView.setFitHeight(32);
-                StackPane.setAlignment(imageView, Pos.TOP_LEFT);
+                StackPane.setAlignment(imageView, Pos.TOP_RIGHT);
                 gameCard.getChildren().add(imageView);
             }
 
             if (gameSummary.getThumbnailLocation() != null) {
                 Image buttonGraphics = new Image(gameSummary.getThumbnailLocation());
                 ImageView imageView = new ImageView(buttonGraphics);
-                imageView.setFitWidth(32);
+                imageView.getStyleClass().add("gameChooserButtonThumbnail");
                 imageView.setPreserveRatio(true);
 
-                int thumbnailBorderSize = 20;
+                int thumbnailBorderSize = 28;
                 gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> imageView
                         .setFitWidth(newValue.doubleValue() - thumbnailBorderSize));
                 gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> imageView
                         .setFitHeight(newValue.doubleValue() - thumbnailBorderSize));
-                StackPane.setAlignment(imageView, Pos.CENTER);
+                StackPane.setAlignment(imageView, Pos.CENTER_LEFT);
                 gameCard.getChildren().add(imageView);
             }
 

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -10,6 +10,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuBar;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.effect.BoxBlur;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -39,16 +40,6 @@ import java.util.List;
 @Data
 @Slf4j
 public class HomeMenuScreen extends GraphicalContext<BorderPane> {
-
-    /**
-     * The horizontal growing factor for buttons to adapt screen size.
-     */
-    private final static double GAME_CHOOSER_BUTTON_HGROW_FACTOR = 3.6;
-
-    /**
-     * The vertical growing factor for buttons to adapt screen size.
-     */
-    private final static double GAME_CHOOSER_BUTTON_VGROW_FACTOR = 8.5;
 
     public static HomeMenuScreen newInstance(final GazePlay gazePlay, final Configuration config) {
 
@@ -103,7 +94,7 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         topRightPane.setAlignment(Pos.TOP_CENTER);
         topRightPane.getChildren().add(exitButton);
 
-        Pane gamePickerChoicePane = createGamePickerChoicePane(games, config);
+        ScrollPane gamePickerChoicePane = createGamePickerChoicePane(games, config);
 
         VBox centerCenterPane = new VBox();
         centerCenterPane.setSpacing(40);
@@ -185,12 +176,15 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         return dialog;
     }
 
-    private Pane createGamePickerChoicePane(List<GameSpec> games, Configuration config) {
+    private ScrollPane createGamePickerChoicePane(List<GameSpec> games, Configuration config) {
 
         FlowPane choicePanel = new FlowPane();
         choicePanel.setAlignment(Pos.CENTER);
         choicePanel.setHgap(10);
         choicePanel.setVgap(10);
+
+        ScrollPane choicePanelScroller = new ScrollPane(choicePanel);
+        choicePanelScroller.setFitToWidth(true);
 
         Multilinguism multilinguism = Multilinguism.getSingleton();
 
@@ -236,21 +230,6 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
             text.setPadding(new Insets(20, 20, 20, 20));
             gameCard.getChildren().add(text);
 
-            Stage primaryStage = GazePlay.getInstance().getPrimaryStage();
-
-            // Adapt buttons size to screen size
-            primaryStage.heightProperty().addListener((o) -> {
-                if (choicePanel.getHeight() > 0) {
-                    gameCard.setPrefHeight(primaryStage.getHeight() / GAME_CHOOSER_BUTTON_VGROW_FACTOR);
-                }
-            });
-
-            primaryStage.widthProperty().addListener((o) -> {
-                if (choicePanel.getHeight() > 0) {
-                    gameCard.setPrefWidth(primaryStage.getWidth() / GAME_CHOOSER_BUTTON_HGROW_FACTOR);
-                }
-            });
-
             gameCard.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
                 @Override
                 public void handle(MouseEvent mouseEvent) {
@@ -283,7 +262,7 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
             choicePanel.getChildren().add(gameCard);
         }
 
-        return choicePanel;
+        return choicePanelScroller;
     }
 
     private void chooseGame(GameSpec selectedGameSpec, GameSpec.GameVariant gameVariant) {

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -147,8 +147,6 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         FlowPane choicePane = new FlowPane();
         choicePane.setAlignment(Pos.CENTER);
 
-        GazePlay gazePlay = GazePlay.getInstance();
-
         for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
             Button button = new Button(variant.getLabel());
             button.getStyleClass().add("gameChooserButton");
@@ -182,9 +180,11 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         choicePanel.setAlignment(Pos.CENTER);
         choicePanel.setHgap(10);
         choicePanel.setVgap(10);
+        choicePanel.setOpaqueInsets(new Insets(20, 20, 20, 20));
 
         ScrollPane choicePanelScroller = new ScrollPane(choicePanel);
         choicePanelScroller.setFitToWidth(true);
+        choicePanelScroller.setFitToHeight(true);
 
         Multilinguism multilinguism = Multilinguism.getSingleton();
 
@@ -205,8 +205,11 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
                 Image buttonGraphics = new Image(gameSummary.getGameTypeIndicatorImageLocation());
                 ImageView imageView = new ImageView(buttonGraphics);
                 imageView.getStyleClass().add("gameChooserButtonGameTypeIndicator");
-                imageView.setFitWidth(32);
-                imageView.setFitHeight(32);
+                imageView.setPreserveRatio(true);
+
+                gameCard.heightProperty().addListener(
+                        (observableValue, oldValue, newValue) -> imageView.setFitHeight(newValue.doubleValue() / 5));
+
                 StackPane.setAlignment(imageView, Pos.TOP_RIGHT);
                 gameCard.getChildren().add(imageView);
             }
@@ -227,7 +230,6 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
             }
 
             StackPane.setAlignment(text, Pos.BOTTOM_RIGHT);
-            text.setPadding(new Insets(20, 20, 20, 20));
             gameCard.getChildren().add(text);
 
             gameCard.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -154,7 +154,7 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
             Button button = new Button(variant.getLabel());
             button.getStyleClass().add("gameChooserButton");
-            button.getStyleClass().add("variant");
+            button.getStyleClass().add("gameVariation");
             button.getStyleClass().add("button");
             choicePane.getChildren().add(button);
 

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/CssUtil.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/CssUtil.java
@@ -2,6 +2,7 @@ package net.gazeplay.commons.utils;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Scene;
+import javafx.stage.Screen;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.themes.BuiltInUiTheme;
@@ -12,6 +13,8 @@ import java.util.Optional;
 
 @Slf4j
 public class CssUtil {
+
+    private static int[] supportedWidth = { 2560, 1920, 1600, 1440, 1280, 1024, 800 };
 
     public static void setPreferredStylesheets(Configuration config, Scene scene) {
         ObservableList<String> stylesheets = scene.getStylesheets();
@@ -36,12 +39,28 @@ public class CssUtil {
 
         stylesheets.add("data/stylesheets/base.css");
 
+        addMediaWidthStylesheet(stylesheets);
+
         if (styleSheetPath != null) {
             stylesheets.add(styleSheetPath);
         }
 
         Utils.addStylesheets(stylesheets);
         log.info(stylesheets.toString());
+    }
+
+    private static void addMediaWidthStylesheet(ObservableList<String> stylesheets) {
+        final int actualScreenWidth = (int) Screen.getPrimary().getBounds().getWidth();
+        log.info("actualScreenWidth = {}", actualScreenWidth);
+
+        for (int width : supportedWidth) {
+            if (width <= actualScreenWidth) {
+                String stylesheet = "data/stylesheets/base-max-width-" + String.format("%04d", width) + ".css";
+                stylesheets.add(stylesheet);
+                log.info("Added : {}", stylesheet);
+                return;
+            }
+        }
     }
 
 }

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/CssUtil.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/CssUtil.java
@@ -11,6 +11,8 @@ import net.gazeplay.commons.utils.games.Utils;
 import java.io.File;
 import java.util.Optional;
 
+import static net.gazeplay.commons.utils.games.Utils.FILESEPARATOR;
+
 @Slf4j
 public class CssUtil {
 
@@ -45,7 +47,7 @@ public class CssUtil {
             stylesheets.add(styleSheetPath);
         }
 
-        Utils.addStylesheets(stylesheets);
+        addStylesheets(stylesheets);
         log.info(stylesheets.toString());
     }
 
@@ -61,6 +63,29 @@ public class CssUtil {
                 return;
             }
         }
+    }
+
+    /**
+     * @return CSS files found in the styles folder
+     */
+    public static void addStylesheets(ObservableList<String> styleSheets) {
+        final File styleFolder = new File(getStylesFolder());
+        if (styleFolder.exists()) {
+            File[] filesInStyleFolder = styleFolder.listFiles();
+            assert filesInStyleFolder != null;
+            for (File f : filesInStyleFolder) {
+                if (f.toString().endsWith(".css")) {
+                    styleSheets.add("file://" + f.toString());
+                }
+            }
+        }
+    }
+
+    /**
+     * @return styles directory for GazePlay : in the default directory of GazePlay, a folder called styles
+     */
+    public static String getStylesFolder() {
+        return Utils.getGazePlayFolder() + "styles" + FILESEPARATOR;
     }
 
 }


### PR DESCRIPTION
Multiple improvement on the graphical design of the game home menu

- game thumbnail is now on the left of the button, and the game name is bigger on the right
- buttons do not resize when the window resizes. This is better as the button will always look the same whatever the window size.
- use a ScrollPane in order to contain the FlowPane. This permits the buttons to flow according to the available size. When the window is reduced, a scoller is displayed, so that the user can scroll down and up to see all the buttons
- introduced a CSS stylesheet per screen resolution. The screen width is detected, and according to this, an additional stylesheet is loaded, that can override any base style. This permits to have the best size for each resolution. This avoids having to use code to implement dynamic sizing of UI elements.

Before
![capture d ecran de 2018-02-25 12-24-44](https://user-images.githubusercontent.com/1653590/36640931-14029762-1a28-11e8-83ab-9b6cdf3ff8bf.png)

After
![capture d ecran de 2018-02-25 12-23-35](https://user-images.githubusercontent.com/1653590/36640933-201a1192-1a28-11e8-85b9-d1000ac35220.png)



