### PR TITLE
Fix issue#227

### DIFF
--- a/gazeplay/src/main/java/net/gazeplay/GameContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameContext.java
@@ -27,6 +27,8 @@ import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.commons.utils.stats.Stats;
 
 import java.io.IOException;
+import javafx.application.Platform;
+import javafx.scene.control.Label;
 
 @Slf4j
 public class GameContext extends GraphicalContext<Pane> {
@@ -148,7 +150,8 @@ public class GameContext extends GraphicalContext<Pane> {
     public HomeButton createHomeButtonInGameScreen(@NonNull GazePlay gazePlay, @NonNull Stats stats) {
 
         EventHandler<Event> homeEvent = e -> {
-            scene.setCursor(Cursor.WAIT); // Change cursor to wait style
+            
+            getScene().setCursor(Cursor.WAIT); // Change cursor to wait style
             homeButtonClicked(stats, gazePlay);
             BackgroundMusicManager.getInstance().pauseAll();
             scene.setCursor(Cursor.DEFAULT); // Change cursor to default style

--- a/gazeplay/src/main/java/net/gazeplay/GameContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameContext.java
@@ -150,8 +150,7 @@ public class GameContext extends GraphicalContext<Pane> {
     public HomeButton createHomeButtonInGameScreen(@NonNull GazePlay gazePlay, @NonNull Stats stats) {
 
         EventHandler<Event> homeEvent = e -> {
-
-            getScene().setCursor(Cursor.WAIT); // Change cursor to wait style
+            scene.setCursor(Cursor.WAIT); // Change cursor to wait style
             homeButtonClicked(stats, gazePlay);
             BackgroundMusicManager.getInstance().pauseAll();
             scene.setCursor(Cursor.DEFAULT); // Change cursor to default style

--- a/gazeplay/src/main/java/net/gazeplay/GameContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameContext.java
@@ -150,7 +150,7 @@ public class GameContext extends GraphicalContext<Pane> {
     public HomeButton createHomeButtonInGameScreen(@NonNull GazePlay gazePlay, @NonNull Stats stats) {
 
         EventHandler<Event> homeEvent = e -> {
-            
+
             getScene().setCursor(Cursor.WAIT); // Change cursor to wait style
             homeButtonClicked(stats, gazePlay);
             BackgroundMusicManager.getInstance().pauseAll();

--- a/gazeplay/src/main/java/net/gazeplay/GameContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameContext.java
@@ -27,8 +27,6 @@ import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.commons.utils.stats.Stats;
 
 import java.io.IOException;
-import javafx.application.Platform;
-import javafx.scene.control.Label;
 
 @Slf4j
 public class GameContext extends GraphicalContext<Pane> {

--- a/gazeplay/src/main/java/net/gazeplay/games/magiccards/Card.java
+++ b/gazeplay/src/main/java/net/gazeplay/games/magiccards/Card.java
@@ -43,7 +43,7 @@ public class Card extends Parent {
 
     private final double initX;
     private final double initY;
-    
+
     private final MagicCards gameInstance;
 
     /**
@@ -57,10 +57,9 @@ public class Card extends Parent {
     final Stats stats;
 
     final EventHandler<Event> enterEvent;
-    
+
     /**
-     * Use a comme Timeline object so we can stop the current animation to 
-     * prevent overlapses.
+     * Use a comme Timeline object so we can stop the current animation to prevent overlapses.
      */
     private Timeline currentTimeline;
 
@@ -83,7 +82,7 @@ public class Card extends Parent {
 
         this.initWidth = width;
         this.initHeight = height;
-        
+
         this.initX = positionX;
         this.initY = positionY;
 
@@ -98,7 +97,7 @@ public class Card extends Parent {
 
         this.addEventFilter(MouseEvent.ANY, enterEvent);
         this.addEventFilter(GazeEvent.ANY, enterEvent);
-        
+
         // Prevent null pointer exception
         currentTimeline = new Timeline();
     }
@@ -175,7 +174,7 @@ public class Card extends Parent {
     }
 
     private EventHandler<Event> buildEvent() {
-        
+
         return new EventHandler<Event>() {
             @Override
             public void handle(Event e) {
@@ -241,11 +240,11 @@ public class Card extends Parent {
                             .add(new KeyFrame(new Duration(1), new KeyValue(card.widthProperty(), initWidth)));
                     currentTimeline.getKeyFrames()
                             .add(new KeyFrame(new Duration(1), new KeyValue(card.heightProperty(), initHeight)));
-                    
+
                     // Be sure that the card is properly positionned at the end
                     currentTimeline.setOnFinished((event) -> {
-                       card.setX(initX);
-                       card.setY(initY);
+                        card.setX(initX);
+                        card.setY(initY);
                     });
 
                     currentTimeline.play();


### PR DESCRIPTION
Fixed by adding an event when the dezoom animation is finished. The event set the X and Y of the card to the initial ones so we are sure that the card will be at its initial position.
This should do it for this issue. I've tested it a little but it may be not enough. Don't hesitate to reopen the issue if it is still there