### PR TITLE
game menu buttons as vertical cards

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/Configuration.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/Configuration.java
@@ -27,6 +27,8 @@ public class Configuration {
 
     private final boolean enableRewardSound;
 
+    private final String menuButtonsOrientation;
+
     protected Configuration(ConfigurationBuilder builder) {
         this.gazeMode = builder.gazeMode;
         this.eyetracker = builder.eyetracker;
@@ -37,6 +39,7 @@ public class Configuration {
         this.whereIsItDir = builder.whereIsItDir;
         this.questionLength = builder.questionLength;
         this.enableRewardSound = builder.enableRewardSound;
+        this.menuButtonsOrientation = builder.menuButtonsOrientation;
     }
 
 }

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/ConfigurationBuilder.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/configuration/ConfigurationBuilder.java
@@ -21,6 +21,7 @@ public class ConfigurationBuilder implements Cloneable {
     private static String PROPERTY_NAME_WHEREISIT_DIR = "WHEREISITDIR";
     private static String PROPERTY_NAME_QUESTION_LENGTH = "QUESTIONLENGTH";
     private static final String PROPERTY_NAME_ENABLE_REWARD_SOUND = "ENABLE_REWARD_SOUND";
+    private static final String PROPERTY_NAME_MENU_BUTTONS_ORIENTATION = "MENU_BUTTONS_ORIENTATION";
 
     private static String CONFIGPATH = Utils.getGazePlayFolder() + "GazePlay.properties";
 
@@ -81,6 +82,8 @@ public class ConfigurationBuilder implements Cloneable {
     protected int questionLength = DEFAULT_VALUE_QUESTION_LENGTH;
 
     protected boolean enableRewardSound = DEFAULT_VALUE_ENABLE_REWARD_SOUND;
+
+    protected String menuButtonsOrientation;
 
     public ConfigurationBuilder() {
 
@@ -148,6 +151,12 @@ public class ConfigurationBuilder implements Cloneable {
         return copy;
     }
 
+    public ConfigurationBuilder withMenuButtonsOrientation(String value) {
+        ConfigurationBuilder copy = copy();
+        copy.menuButtonsOrientation = value;
+        return copy;
+    }
+
     public void populateFromProperties(Properties prop) {
         String buffer;
 
@@ -206,6 +215,11 @@ public class ConfigurationBuilder implements Cloneable {
             enableRewardSound = Boolean.parseBoolean(buffer);
         }
 
+        buffer = prop.getProperty(PROPERTY_NAME_MENU_BUTTONS_ORIENTATION);
+        if (buffer != null) {
+            menuButtonsOrientation = buffer;
+        }
+
     }
 
     private Properties toProperties() {
@@ -232,6 +246,7 @@ public class ConfigurationBuilder implements Cloneable {
         properties.setProperty(PROPERTY_NAME_WHEREISIT_DIR, this.whereIsItDir);
         properties.setProperty(PROPERTY_NAME_QUESTION_LENGTH, Integer.toString(this.questionLength));
         properties.setProperty(PROPERTY_NAME_ENABLE_REWARD_SOUND, Boolean.toString(this.enableRewardSound));
+        properties.setProperty(PROPERTY_NAME_MENU_BUTTONS_ORIENTATION, this.menuButtonsOrientation);
 
         return properties;
     }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-0800.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 20em;
     -fx-min-height: 5em;
     -fx-pref-width: 20em;
     -fx-pref-height: 5em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameVariationChooserButton {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1024.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 20em;
     -fx-min-height: 5em;
     -fx-pref-width: 20em;
     -fx-pref-height: 5em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameVariationChooserButton {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1280.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 19em;
     -fx-min-height: 5em;
     -fx-pref-width: 19em;
     -fx-pref-height: 6em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameVariationChooserButton {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1366.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 22em;
     -fx-min-height: 5em;
     -fx-pref-width: 22em;
     -fx-pref-height: 8em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameChooserButtonTitle {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1440.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 18em;
     -fx-min-height: 4em;
     -fx-pref-width: 28em;
     -fx-pref-height: 7em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameChooserButtonTitle {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1600.css
@@ -1,8 +1,15 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 18em;
     -fx-min-height: 4em;
     -fx-pref-width: 28em;
     -fx-pref-height: 7em;
+}
+
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
 }
 
 .gameChooserButtonTitle {

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-1920.css
@@ -1,10 +1,17 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     -fx-min-width: 18em;
     -fx-min-height: 4em;
     -fx-pref-width: 40em;
     -fx-pref-height: 9em;
 }
 
+.gameChooserButtonVertical {
+    -fx-min-width: 14em;
+    -fx-min-height: 14em;
+    -fx-pref-width: 14em;
+    -fx-pref-height: 14em;
+}
+
 .gameChooserButtonTitle {
-    -fx-font-size: 20pt;
+    -fx-font-size: 18pt;
 }

--- a/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
+++ b/gazeplay-data/src/main/resources/data/stylesheets/base-max-width-2560.css
@@ -1,14 +1,21 @@
-.gameChooserButton {
+.gameChooserButtonHorizontal {
     /*-fx-pref-width: 32em;*/
     /*-fx-pref-height: 10em;*/
     -fx-min-width: 18em;
     -fx-min-height: 4em;
-    -fx-pref-width: 40em;
+    -fx-pref-width: 30em;
     -fx-pref-height: 9em;
 }
 
+.gameChooserButtonVertical {
+    -fx-min-width: 16em;
+    -fx-min-height: 20em;
+    -fx-pref-width: 16em;
+    -fx-pref-height: 20em;
+}
+
 .gameChooserButtonTitle {
-    -fx-font-size: 22pt;
+    -fx-font-size: 18pt;
 }
 .gameChooserButton.variant {
     -fx-font-size: 22pt;

--- a/gazeplay/src/main/java/net/gazeplay/ConfigurationContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/ConfigurationContext.java
@@ -198,6 +198,13 @@ public class ConfigurationContext extends GraphicalContext<BorderPane> {
             addToGrid(grid, currentFormRow, label, input);
         }
 
+        {
+            I18NText label = new I18NText(translator, "Menu Orientation (restart game to take effect)", COLON);
+            ChoiceBox<GameButtonOrientation> input = buildGameButtonOrientationChooser(config, configurationContext);
+
+            addToGrid(grid, currentFormRow, label, input);
+        }
+
         return grid;
     }
 
@@ -513,4 +520,41 @@ public class ConfigurationContext extends GraphicalContext<BorderPane> {
         return enableBox;
     }
 
+    private static ChoiceBox<GameButtonOrientation> buildGameButtonOrientationChooser(Configuration configuration,
+            ConfigurationContext configurationContext) {
+        ChoiceBox<GameButtonOrientation> choiceBox = new ChoiceBox<>();
+
+        choiceBox.getItems().addAll(GameButtonOrientation.values());
+
+        GameButtonOrientation selectedValue = findSelectedGameButtonOrientation(configuration);
+        choiceBox.getSelectionModel().select(selectedValue);
+
+        choiceBox.setPrefWidth(prefWidth);
+        choiceBox.setPrefHeight(prefHeight);
+
+        choiceBox.getSelectionModel().selectedItemProperty().addListener(new ChangeListener<GameButtonOrientation>() {
+            @Override
+            public void changed(ObservableValue<? extends GameButtonOrientation> observable,
+                    GameButtonOrientation oldValue, GameButtonOrientation newValue) {
+                final String newPropertyValue = newValue.name();
+                ConfigurationBuilder.createFromPropertiesResource().withMenuButtonsOrientation(newPropertyValue)
+                        .saveConfigIgnoringExceptions();
+            }
+        });
+
+        return choiceBox;
+    }
+
+    private static GameButtonOrientation findSelectedGameButtonOrientation(Configuration configuration) {
+        final String configValue = configuration.getMenuButtonsOrientation();
+        if (configValue == null) {
+            return null;
+        }
+        try {
+            return GameButtonOrientation.valueOf(configValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("IllegalArgumentException : unsupported GameButtonOrientation value : {}", configValue, e);
+            return null;
+        }
+    }
 }

--- a/gazeplay/src/main/java/net/gazeplay/GameButtonOrientation.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameButtonOrientation.java
@@ -1,0 +1,35 @@
+package net.gazeplay;
+
+import lombok.extern.slf4j.Slf4j;
+import net.gazeplay.commons.configuration.Configuration;
+
+import java.util.Random;
+
+@Slf4j
+public enum GameButtonOrientation {
+    HORIZONTAL, VERTICAL;
+
+    public static GameButtonOrientation getDefault() {
+        return HORIZONTAL;
+    }
+
+    public static GameButtonOrientation random() {
+        GameButtonOrientation[] values = values();
+        int randomIndex = new Random().nextInt(values.length);
+        return values[randomIndex];
+    }
+
+    public static GameButtonOrientation fromConfig(Configuration config) {
+        String configValue = config.getMenuButtonsOrientation();
+        if (configValue == null) {
+            return getDefault();
+        }
+        try {
+            return valueOf(configValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("IllegalArgumentException : config value is invalid : {}", configValue, e);
+            return getDefault();
+        }
+    }
+
+}

--- a/gazeplay/src/main/java/net/gazeplay/GameMenuFactory.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameMenuFactory.java
@@ -1,0 +1,295 @@
+package net.gazeplay;
+
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.effect.BoxBlur;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.text.TextAlignment;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import lombok.extern.slf4j.Slf4j;
+import net.gazeplay.commons.configuration.Configuration;
+import net.gazeplay.commons.configuration.ConfigurationBuilder;
+import net.gazeplay.commons.ui.I18NText;
+import net.gazeplay.commons.ui.Translator;
+import net.gazeplay.commons.utils.CssUtil;
+import net.gazeplay.commons.utils.games.BackgroundMusicManager;
+import net.gazeplay.commons.utils.multilinguism.Multilinguism;
+import net.gazeplay.commons.utils.stats.Stats;
+
+import java.util.Collection;
+
+@Slf4j
+public class GameMenuFactory {
+
+    private boolean useDebuggingBackgrounds = false;
+
+    public Pane createGameButton(GazePlay gazePlay, Scene scene, Configuration config, Multilinguism multilinguism,
+            Translator translator, GameSpec gameSpec, GameButtonOrientation orientation) {
+
+        final GameSummary gameSummary = gameSpec.getGameSummary();
+        final String gameName = multilinguism.getTrad(gameSummary.getNameCode(), config.getLanguage());
+
+        final I18NText gameTitleText = new I18NText(translator, gameSummary.getNameCode());
+        gameTitleText.getStyleClass().add("gameChooserButtonTitle");
+
+        BorderPane thumbnailImageViewContainer = new BorderPane();
+        thumbnailImageViewContainer.setPadding(new Insets(1, 1, 1, 1));
+        thumbnailImageViewContainer.setOpaqueInsets(new Insets(1, 1, 1, 1));
+        if (useDebuggingBackgrounds) {
+            thumbnailImageViewContainer
+                    .setBackground(new Background(new BackgroundFill(Color.DARKGREY, CornerRadii.EMPTY, Insets.EMPTY)));
+        }
+
+        BorderPane gameCard = new BorderPane();
+        switch (orientation) {
+        case HORIZONTAL:
+            gameCard.getStyleClass().add("gameChooserButton");
+            gameCard.getStyleClass().add("gameChooserButtonHorizontal");
+            break;
+        case VERTICAL:
+            gameCard.getStyleClass().add("gameChooserButton");
+            gameCard.getStyleClass().add("gameChooserButtonVertical");
+            break;
+        }
+
+        if (useDebuggingBackgrounds) {
+            gameCard.setBackground(new Background(new BackgroundFill(Color.RED, CornerRadii.EMPTY, Insets.EMPTY)));
+        }
+
+        gameCard.getStyleClass().add("button");
+
+        double thumbnailBorderSize = 28d;
+
+        BorderPane gameDescriptionPane = new BorderPane();
+        if (useDebuggingBackgrounds) {
+            gameDescriptionPane
+                    .setBackground(new Background(new BackgroundFill(Color.WHITE, CornerRadii.EMPTY, Insets.EMPTY)));
+        }
+
+        if (gameSummary.getThumbnailLocation() != null) {
+            Image buttonGraphics = new Image(gameSummary.getThumbnailLocation());
+            ImageView imageView = new ImageView(buttonGraphics);
+            imageView.getStyleClass().add("gameChooserButtonThumbnail");
+            imageView.setPreserveRatio(true);
+            StackPane.setAlignment(imageView, Pos.CENTER);
+            thumbnailImageViewContainer.setCenter(imageView);
+
+            double imageSizeRatio = buttonGraphics.getWidth() / buttonGraphics.getHeight();
+
+            switch (orientation) {
+            case HORIZONTAL:
+                gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> {
+                    double preferedHeight = newValue.doubleValue() - thumbnailBorderSize;
+                    imageView.setFitHeight(preferedHeight);
+                    imageView.setFitWidth(preferedHeight * imageSizeRatio);
+                });
+                // gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> {
+                // imageView.setFitWidth(newValue.doubleValue() / 2);
+                // });
+                break;
+            case VERTICAL:
+                gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> {
+                    double preferedWidth = newValue.doubleValue() - thumbnailBorderSize;
+                    imageView.setFitWidth(preferedWidth);
+                    imageView.setFitHeight(preferedWidth / buttonGraphics.getWidth() * buttonGraphics.getHeight());
+                });
+                gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> {
+                    imageView.setFitHeight(newValue.doubleValue() / 2);
+                });
+                break;
+            }
+
+        }
+
+        if (gameSummary.getGameTypeIndicatorImageLocation() != null) {
+            Image buttonGraphics = new Image(gameSummary.getGameTypeIndicatorImageLocation());
+            ImageView imageView = new ImageView(buttonGraphics);
+            imageView.getStyleClass().add("gameChooserButtonGameTypeIndicator");
+            imageView.setPreserveRatio(true);
+
+            switch (orientation) {
+            case HORIZONTAL:
+                gameCard.heightProperty().addListener(
+                        (observableValue, oldValue, newValue) -> imageView.setFitHeight(newValue.doubleValue() / 10));
+                StackPane.setAlignment(imageView, Pos.BOTTOM_RIGHT);
+                break;
+            case VERTICAL:
+                gameCard.widthProperty().addListener(
+                        (observableValue, oldValue, newValue) -> imageView.setFitWidth(newValue.doubleValue() / 10));
+                StackPane.setAlignment(imageView, Pos.BOTTOM_RIGHT);
+                break;
+            }
+
+            final VBox gameTypeIndicatorImageViewContainer = new VBox();
+            gameTypeIndicatorImageViewContainer.setAlignment(Pos.BOTTOM_RIGHT);
+            gameTypeIndicatorImageViewContainer.getChildren().add(imageView);
+
+            gameDescriptionPane.setBottom(gameTypeIndicatorImageViewContainer);
+        }
+
+        final VBox gameTitleContainer = new VBox();
+        gameTitleContainer.getChildren().add(gameTitleText);
+        gameDescriptionPane.setTop(gameTitleContainer);
+
+        switch (orientation) {
+        case HORIZONTAL:
+            gameDescriptionPane.setPadding(new Insets(0, 10, 0, 10));
+
+            gameCard.setRight(gameDescriptionPane);
+            gameCard.setLeft(thumbnailImageViewContainer);
+
+            // thumbnailImageViewContainer.setAlignment(Pos.CENTER);
+            StackPane.setAlignment(gameTitleText, Pos.TOP_RIGHT);
+            gameTitleContainer.setAlignment(Pos.TOP_RIGHT);
+            gameTitleText.setTextAlignment(TextAlignment.RIGHT);
+
+            gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> {
+                // thumbnailImageViewContainer.setPrefWidth(newValue.doubleValue() / 2);
+                thumbnailImageViewContainer.setPrefHeight(newValue.doubleValue() / 2 / 16 * 9);
+                gameDescriptionPane.setPrefHeight(newValue.doubleValue() - thumbnailBorderSize);
+            });
+            gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> {
+                thumbnailImageViewContainer.setPrefWidth(newValue.doubleValue() / 2 - thumbnailBorderSize);
+                thumbnailImageViewContainer.setMaxWidth(newValue.doubleValue() / 2 - thumbnailBorderSize);
+                gameDescriptionPane.setPrefWidth(newValue.doubleValue() / 2 - thumbnailBorderSize);
+                gameDescriptionPane.setMaxWidth(newValue.doubleValue() / 2 - thumbnailBorderSize);
+                gameTitleText.setWrappingWidth(newValue.doubleValue() / 2 - thumbnailBorderSize);
+
+            });
+
+            break;
+        case VERTICAL:
+            gameDescriptionPane.setPadding(new Insets(10, 0, 10, 0));
+
+            gameCard.setBottom(gameDescriptionPane);
+            gameCard.setTop(thumbnailImageViewContainer);
+
+            // thumbnailImageViewContainer.setAlignment(Pos.CENTER);
+            StackPane.setAlignment(gameTitleText, Pos.TOP_CENTER);
+            gameTitleContainer.setAlignment(Pos.TOP_CENTER);
+            gameTitleText.setTextAlignment(TextAlignment.CENTER);
+
+            gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> {
+                thumbnailImageViewContainer.setPrefWidth(newValue.doubleValue() - thumbnailBorderSize);
+                gameDescriptionPane.setPrefWidth(newValue.doubleValue() - thumbnailBorderSize);
+                gameTitleText.setWrappingWidth(newValue.doubleValue() - thumbnailBorderSize);
+            });
+            gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> {
+                thumbnailImageViewContainer.setPrefHeight(newValue.doubleValue() / 2);
+                gameDescriptionPane.setPrefHeight(newValue.doubleValue() / 2);
+            });
+
+            break;
+        }
+
+        gameCard.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
+            @Override
+            public void handle(MouseEvent mouseEvent) {
+                Collection<GameSpec.GameVariant> variants = gameSpec.getGameVariantGenerator().getVariants();
+
+                if (variants.size() > 1) {
+                    log.info("variants = {}", variants);
+                    scene.getRoot().setEffect(new BoxBlur());
+                    Stage dialog = createDialog(gazePlay, gazePlay.getPrimaryStage(), gameSpec);
+
+                    String dialogTitle = gameName + " : "
+                            + multilinguism.getTrad("Choose Game Variante", config.getLanguage());
+                    dialog.setTitle(dialogTitle);
+                    dialog.show();
+
+                    dialog.toFront();
+                    dialog.setAlwaysOnTop(true);
+
+                } else {
+                    if (variants.size() == 1) {
+                        GameSpec.GameVariant onlyGameVariant = variants.iterator().next();
+                        chooseGame(gazePlay, gameSpec, onlyGameVariant);
+                    } else {
+                        chooseGame(gazePlay, gameSpec, null);
+                    }
+                }
+            }
+        });
+
+        return gameCard;
+    }
+
+    private Stage createDialog(GazePlay gazePlay, Stage primaryStage, GameSpec gameSpec) {
+        // initialize the confirmation dialog
+        final Stage dialog = new Stage();
+        dialog.initModality(Modality.WINDOW_MODAL);
+        dialog.initOwner(primaryStage);
+        dialog.initStyle(StageStyle.UTILITY);
+        dialog.setOnCloseRequest(windowEvent -> primaryStage.getScene().getRoot().setEffect(null));
+
+        FlowPane choicePane = new FlowPane();
+        choicePane.setAlignment(Pos.CENTER);
+
+        ScrollPane choicePanelScroller = new ScrollPane(choicePane);
+        choicePanelScroller.setFitToWidth(true);
+        choicePanelScroller.setFitToHeight(true);
+
+        for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
+            Button button = new Button(variant.getLabel());
+            button.getStyleClass().add("gameChooserButton");
+            button.getStyleClass().add("gameVariation");
+            button.getStyleClass().add("button");
+            choicePane.getChildren().add(button);
+
+            button.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
+                @Override
+                public void handle(MouseEvent mouseEvent) {
+                    dialog.close();
+                    chooseGame(gazePlay, gameSpec, variant);
+                }
+            });
+        }
+
+        Scene scene = new Scene(choicePanelScroller, Color.TRANSPARENT);
+
+        final Configuration config = ConfigurationBuilder.createFromPropertiesResource().build();
+        CssUtil.setPreferredStylesheets(config, scene);
+
+        dialog.setScene(scene);
+        // scene.getStylesheets().add(getClass().getResource("modal-dialog.css").toExternalForm());
+
+        return dialog;
+    }
+
+    private void chooseGame(GazePlay gazePlay, GameSpec selectedGameSpec, GameSpec.GameVariant gameVariant) {
+        GameContext gameContext = GameContext.newInstance(gazePlay);
+
+        // SecondScreen secondScreen = SecondScreen.launch();
+
+        gazePlay.onGameLaunch(gameContext);
+
+        GameSpec.GameLauncher gameLauncher = selectedGameSpec.getGameLauncher();
+
+        final Stats stats = gameLauncher.createNewStats(gameContext.getScene());
+
+        gameContext.getGazeDeviceManager().addGazeMotionListener(stats);
+        // gameContext.getGazeDeviceManager().addGazeMotionListener(secondScreen);
+
+        GameLifeCycle currentGame = gameLauncher.createNewGame(gameContext, gameVariant, stats);
+
+        gameContext.createControlPanel(gazePlay, stats, currentGame);
+
+        if (selectedGameSpec.getGameSummary().getBackgroundMusicUrl() != null) {
+            BackgroundMusicManager.getInstance()
+                    .playRemoteSound(selectedGameSpec.getGameSummary().getBackgroundMusicUrl());
+        }
+
+        currentGame.launch();
+    }
+
+}

--- a/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
+++ b/gazeplay/src/main/java/net/gazeplay/HomeMenuScreen.java
@@ -10,33 +10,24 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.effect.BoxBlur;
 import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.ImagePattern;
 import javafx.scene.shape.Rectangle;
-import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.StageStyle;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.commons.configuration.Configuration;
-import net.gazeplay.commons.configuration.ConfigurationBuilder;
-import net.gazeplay.commons.utils.games.BackgroundMusicManager;
-import net.gazeplay.commons.utils.multilinguism.Multilinguism;
-import net.gazeplay.commons.ui.I18NLabel;
 import net.gazeplay.commons.ui.Translator;
 import net.gazeplay.commons.utils.ConfigurationButton;
 import net.gazeplay.commons.utils.ControlPanelConfigurator;
-import net.gazeplay.commons.utils.CssUtil;
 import net.gazeplay.commons.utils.CustomButton;
+import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 import net.gazeplay.commons.utils.games.Utils;
-import net.gazeplay.commons.utils.stats.Stats;
+import net.gazeplay.commons.utils.multilinguism.Multilinguism;
 
-import java.util.Collection;
 import java.util.List;
 
 @Data
@@ -59,6 +50,8 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
     private final List<GameSpec> games;
 
     private GameLifeCycle currentGame;
+
+    private final GameMenuFactory gameMenuFactory = new GameMenuFactory();
 
     public HomeMenuScreen(GazePlay gazePlay, List<GameSpec> games, Scene scene, BorderPane root, Configuration config) {
         super(gazePlay, root, scene);
@@ -97,7 +90,7 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         topRightPane.setAlignment(Pos.TOP_CENTER);
         topRightPane.getChildren().add(exitButton);
 
-        ScrollPane gamePickerChoicePane = createGamePickerChoicePane(games, config);
+        Node gamePickerChoicePane = createGamePickerChoicePane(games, config);
 
         VBox centerCenterPane = new VBox();
         centerCenterPane.setSpacing(40);
@@ -146,55 +139,15 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
         // BackgroundMusicManager.getInstance().playRemoteSound(resourceLocation2);
     }
 
-    private Stage createDialog(Stage primaryStage, GameSpec gameSpec) {
-        // initialize the confirmation dialog
-        final Stage dialog = new Stage();
-        dialog.initModality(Modality.WINDOW_MODAL);
-        dialog.initOwner(primaryStage);
-        dialog.initStyle(StageStyle.UTILITY);
-        dialog.setOnCloseRequest(windowEvent -> primaryStage.getScene().getRoot().setEffect(null));
-
-        FlowPane choicePane = new FlowPane();
-        choicePane.setAlignment(Pos.CENTER);
-
-        ScrollPane choicePanelScroller = new ScrollPane(choicePane);
-        choicePanelScroller.setFitToWidth(true);
-        choicePanelScroller.setFitToHeight(true);
-
-        for (GameSpec.GameVariant variant : gameSpec.getGameVariantGenerator().getVariants()) {
-            Button button = new Button(variant.getLabel());
-            button.getStyleClass().add("gameChooserButton");
-            button.getStyleClass().add("gameVariation");
-            button.getStyleClass().add("button");
-            choicePane.getChildren().add(button);
-
-            button.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
-                @Override
-                public void handle(MouseEvent mouseEvent) {
-                    dialog.close();
-                    chooseGame(gameSpec, variant);
-                }
-            });
-        }
-
-        Scene scene = new Scene(choicePanelScroller, Color.TRANSPARENT);
-
-        final Configuration config = ConfigurationBuilder.createFromPropertiesResource().build();
-        CssUtil.setPreferredStylesheets(config, scene);
-
-        dialog.setScene(scene);
-        // scene.getStylesheets().add(getClass().getResource("modal-dialog.css").toExternalForm());
-
-        return dialog;
-    }
-
     private ScrollPane createGamePickerChoicePane(List<GameSpec> games, Configuration config) {
 
-        FlowPane choicePanel = new FlowPane();
+        final int flowpaneGap = 20;
+
+        final FlowPane choicePanel = new FlowPane();
         choicePanel.setAlignment(Pos.CENTER);
-        choicePanel.setHgap(10);
-        choicePanel.setVgap(10);
-        choicePanel.setOpaqueInsets(new Insets(20, 20, 20, 20));
+        choicePanel.setHgap(flowpaneGap);
+        choicePanel.setVgap(flowpaneGap);
+        choicePanel.setPadding(new Insets(20, 60, 20, 60));
 
         ScrollPane choicePanelScroller = new ScrollPane(choicePanel);
         choicePanelScroller.setFitToWidth(true);
@@ -204,111 +157,15 @@ public class HomeMenuScreen extends GraphicalContext<BorderPane> {
 
         final Translator translator = getGazePlay().getTranslator();
 
+        final GameButtonOrientation gameButtonOrientation = GameButtonOrientation.fromConfig(config);
+
         for (GameSpec gameSpec : games) {
-            final GameSummary gameSummary = gameSpec.getGameSummary();
-
-            String gameName = multilinguism.getTrad(gameSummary.getNameCode(), config.getLanguage());
-
-            StackPane gameCard = new StackPane();
-            gameCard.getStyleClass().add("gameChooserButton");
-            gameCard.getStyleClass().add("button");
-
-            I18NLabel text = new I18NLabel(translator, gameSummary.getNameCode());
-
-            text.getStyleClass().add("gameChooserButtonTitle");
-
-            if (gameSummary.getGameTypeIndicatorImageLocation() != null) {
-                Image buttonGraphics = new Image(gameSummary.getGameTypeIndicatorImageLocation());
-                ImageView imageView = new ImageView(buttonGraphics);
-                imageView.getStyleClass().add("gameChooserButtonGameTypeIndicator");
-                imageView.setPreserveRatio(true);
-
-                gameCard.heightProperty().addListener(
-                        (observableValue, oldValue, newValue) -> imageView.setFitHeight(newValue.doubleValue() / 5));
-
-                StackPane.setAlignment(imageView, Pos.TOP_RIGHT);
-                gameCard.getChildren().add(imageView);
-            }
-
-            if (gameSummary.getThumbnailLocation() != null) {
-                Image buttonGraphics = new Image(gameSummary.getThumbnailLocation());
-                ImageView imageView = new ImageView(buttonGraphics);
-                imageView.getStyleClass().add("gameChooserButtonThumbnail");
-                imageView.setPreserveRatio(true);
-
-                int thumbnailBorderSize = 28;
-                gameCard.widthProperty().addListener((observableValue, oldValue, newValue) -> imageView
-                        .setFitWidth(newValue.doubleValue() - thumbnailBorderSize));
-                gameCard.heightProperty().addListener((observableValue, oldValue, newValue) -> imageView
-                        .setFitHeight(newValue.doubleValue() - thumbnailBorderSize));
-                StackPane.setAlignment(imageView, Pos.CENTER_LEFT);
-                gameCard.getChildren().add(imageView);
-            }
-
-            StackPane.setAlignment(text, Pos.BOTTOM_RIGHT);
-            gameCard.getChildren().add(text);
-
-            gameCard.addEventHandler(MouseEvent.MOUSE_CLICKED, new EventHandler<MouseEvent>() {
-                @Override
-                public void handle(MouseEvent mouseEvent) {
-                    Collection<GameSpec.GameVariant> variants = gameSpec.getGameVariantGenerator().getVariants();
-
-                    if (variants.size() > 1) {
-                        log.info("variants = {}", variants);
-                        getScene().getRoot().setEffect(new BoxBlur());
-                        Stage dialog = createDialog(getGazePlay().getPrimaryStage(), gameSpec);
-
-                        String dialogTitle = gameName + " : "
-                                + multilinguism.getTrad("Choose Game Variante", config.getLanguage());
-                        dialog.setTitle(dialogTitle);
-                        dialog.show();
-
-                        dialog.toFront();
-                        dialog.setAlwaysOnTop(true);
-
-                    } else {
-                        if (variants.size() == 1) {
-                            GameSpec.GameVariant onlyGameVariant = variants.iterator().next();
-                            chooseGame(gameSpec, onlyGameVariant);
-                        } else {
-                            chooseGame(gameSpec, null);
-                        }
-                    }
-                }
-            });
-
+            final Pane gameCard = gameMenuFactory.createGameButton(getGazePlay(), getScene(), config, multilinguism,
+                    translator, gameSpec, gameButtonOrientation);
             choicePanel.getChildren().add(gameCard);
         }
 
         return choicePanelScroller;
-    }
-
-    private void chooseGame(GameSpec selectedGameSpec, GameSpec.GameVariant gameVariant) {
-        GazePlay gazePlay = getGazePlay();
-
-        GameContext gameContext = GameContext.newInstance(gazePlay);
-
-        // SecondScreen secondScreen = SecondScreen.launch();
-
-        gazePlay.onGameLaunch(gameContext);
-
-        GameSpec.GameLauncher gameLauncher = selectedGameSpec.getGameLauncher();
-
-        final Stats stats = gameLauncher.createNewStats(gameContext.getScene());
-
-        gameContext.getGazeDeviceManager().addGazeMotionListener(stats);
-        // gameContext.getGazeDeviceManager().addGazeMotionListener(secondScreen);
-
-        GameLifeCycle currentGame = gameLauncher.createNewGame(gameContext, gameVariant, stats);
-
-        gameContext.createControlPanel(gazePlay, stats, currentGame);
-
-        if (selectedGameSpec.getGameSummary().getBackgroundMusicUrl() != null) {
-            BackgroundMusicManager.getInstance()
-                    .playRemoteSound(selectedGameSpec.getGameSummary().getBackgroundMusicUrl());
-        }
-
-        currentGame.launch();
     }
 
     private Rectangle createExitButton() {


### PR DESCRIPTION
introduce an alternative way of displaying a game menu button, it was formerly only a horizontal card with the thumbnail on the left, now there is also the option of displaying a vertical card with the thumbnail on the top. Vertical card tends to take less space on screen, allowing to display more buttons at once on screen

before (horizontal only)
![before](https://user-images.githubusercontent.com/1653590/37033250-a0ad4a76-2145-11e8-98fb-ed26efd41649.png)

after (horizontal option)
![after-horizontal](https://user-images.githubusercontent.com/1653590/37033261-a8354d52-2145-11e8-8af8-b576d9ee52cf.png)

after (vertical option)
![after-vertical](https://user-images.githubusercontent.com/1653590/37033282-b9b4a00a-2145-11e8-97ab-d79059139a78.png)
