### PR TITLE
clear in shooter + stats homogeneous for shooter at display time

### DIFF
--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
@@ -75,7 +75,10 @@ public class StatsDisplay {
         if (stats instanceof BubblesGamesStats) {
 
             shoots = stats.getSortedLengthBetweenGoals();
-        } else {
+        } else if (stats instanceof ShootGamesStats) {
+
+            shoots = stats.getSortedLengthBetweenGoals();
+        }else {
 
             shoots = stats.getLengthBetweenGoals();
         }

--- a/gazeplay/src/main/java/net/gazeplay/games/shooter/Shooter.java
+++ b/gazeplay/src/main/java/net/gazeplay/games/shooter/Shooter.java
@@ -346,7 +346,7 @@ public class Shooter extends Parent implements GameLifeCycle {
     // done
     @Override
     public void dispose() {
-
+    	this.getChildren().clear(); 	
     }
 
     private Transition restartTransition(Target t) {


### PR DESCRIPTION
Stats are now sorted by length and we're clearing the this.getChildren() list when disposing the shooter game to prevent so java heap memory full error