### PR TITLE
Naming Threads

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/CustomThreadFactory.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/CustomThreadFactory.java
@@ -1,0 +1,41 @@
+package net.gazeplay.commons.threads;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Slf4j
+public class CustomThreadFactory implements ThreadFactory {
+
+    private final String namePrefix;
+
+    private final ThreadFactory delegate;
+
+    public CustomThreadFactory(String namePrefix) {
+        this(namePrefix, Executors.defaultThreadFactory());
+    }
+
+    public CustomThreadFactory(String namePrefix, ThreadFactory delegate) {
+        this.namePrefix = namePrefix;
+        this.delegate = delegate;
+    }
+
+    public Thread newThread(Runnable runnable) {
+        Thread result = delegate.newThread(runnable);
+
+        Class<? extends Runnable> runnableClass = runnable.getClass();
+
+        StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(namePrefix);
+        nameBuilder.append("-");
+        nameBuilder.append(runnableClass.getSimpleName());
+        nameBuilder.append("-");
+        // original name
+        nameBuilder.append(result.getName());
+        result.setName(nameBuilder.toString());
+
+        return result;
+    }
+
+}

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/GroupingThreadFactory.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/GroupingThreadFactory.java
@@ -1,0 +1,37 @@
+package net.gazeplay.commons.threads;
+
+import lombok.Setter;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GroupingThreadFactory implements ThreadFactory {
+
+    private final ThreadGroup threadGroup;
+
+    private final AtomicInteger threadIndex = new AtomicInteger(0);
+
+    /**
+     * by default, the created threads should not be daemons.
+     */
+    @Setter
+    private boolean daemon = false;
+
+    @Setter
+    private Thread.UncaughtExceptionHandler uncaughtExceptionHandler = new LoggingUncaughtExceptionHandler();
+
+    public GroupingThreadFactory(String groupName) {
+        super();
+        threadGroup = new ThreadGroup(groupName);
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread thread = new Thread(threadGroup, r);
+        thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+        thread.setDaemon(daemon);
+        thread.setName("Thread-" + threadIndex.incrementAndGet());
+        return thread;
+    }
+
+}

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/LoggingUncaughtExceptionHandler.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/threads/LoggingUncaughtExceptionHandler.java
@@ -1,0 +1,11 @@
+package net.gazeplay.commons.threads;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoggingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        log.error("uncaughtException in Thread {} : {} : {}", t.getName(), e.getClass().getName(), e.getMessage(), e);
+    }
+}

--- a/gazeplay/src/main/java/net/gazeplay/AsyncUiTaskExecutor.java
+++ b/gazeplay/src/main/java/net/gazeplay/AsyncUiTaskExecutor.java
@@ -1,0 +1,21 @@
+package net.gazeplay;
+
+import lombok.Getter;
+import net.gazeplay.commons.threads.CustomThreadFactory;
+import net.gazeplay.commons.threads.GroupingThreadFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncUiTaskExecutor {
+
+    @Getter
+    private static final AsyncUiTaskExecutor instance = new AsyncUiTaskExecutor();
+
+    @Getter
+    private final ExecutorService executorService = new ThreadPoolExecutor(0, 4, 1, TimeUnit.MINUTES,
+            new LinkedBlockingQueue<>(), new CustomThreadFactory("AsyncUi", new GroupingThreadFactory("AsyncUi")));
+
+}

--- a/gazeplay/src/main/java/net/gazeplay/GameContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/GameContext.java
@@ -181,8 +181,7 @@ public class GameContext extends GraphicalContext<Pane> {
         };
 
         if (runAsynchronousStatsPersist) {
-            Thread asynchronousStatsPersistThread = new Thread(asynchronousStatsPersistTask);
-            asynchronousStatsPersistThread.start();
+            AsyncUiTaskExecutor.getInstance().getExecutorService().execute(asynchronousStatsPersistTask);
         } else {
             asynchronousStatsPersistTask.run();
         }

--- a/gazeplay/src/main/java/net/gazeplay/GazePlayLauncher.java
+++ b/gazeplay/src/main/java/net/gazeplay/GazePlayLauncher.java
@@ -1,7 +1,11 @@
 package net.gazeplay;
 
 import javafx.application.Application;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import net.gazeplay.commons.threads.CustomThreadFactory;
+import net.gazeplay.commons.threads.GroupingThreadFactory;
+import net.gazeplay.commons.threads.LoggingUncaughtExceptionHandler;
 import net.gazeplay.commons.utils.games.Utils;
 import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J;
 
@@ -11,6 +15,7 @@ import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
+import java.util.concurrent.ThreadFactory;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -19,47 +24,76 @@ public class GazePlayLauncher {
 
     private static final String artifactId = "gazeplay";
 
+    @Setter
+    public static boolean doStartBootstrapThread = true;
+
     public static void main(String[] args) {
 
-        SysOutOverSLF4J.sendSystemOutAndErrToSLF4J();
+        Thread.currentThread().setName(GazePlayLauncher.class.getSimpleName() + "-main");
+        Thread.currentThread().setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler());
 
-        Thread.currentThread().setUncaughtExceptionHandler(new GazePlayUncaughtExceptionHandler());
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
 
-        String versionInfo;
-        try {
-            versionInfo = findVersionInfo(artifactId);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to load the version info", e);
-        }
+                SysOutOverSLF4J.sendSystemOutAndErrToSLF4J();
 
-        for (int i = 0; i < 5; i++) {
-            log.info("***********************");
-        }
-        log.info("GazePlay");
-        log.info("Version : " + versionInfo);
-        Utils.logSystemProperties();
-        log.info("Max Memory: " + Runtime.getRuntime().maxMemory());
+                String versionInfo;
+                try {
+                    versionInfo = findVersionInfo(artifactId);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to load the version info", e);
+                }
 
-        try {
-            System.setProperty("file.encoding", "UTF-8");
-            Field charset = Charset.class.getDeclaredField("defaultCharset");
-            charset.setAccessible(true);
-            charset.set(null, null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            log.error("Exception", e);
-        }
+                for (int i = 0; i < 5; i++) {
+                    log.info("***********************");
+                }
+                log.info("GazePlay");
+                log.info("Version : " + versionInfo);
+                Utils.logSystemProperties();
+                log.info("Max Memory: " + Runtime.getRuntime().maxMemory());
 
-        File workingDirectory = new File(".").getAbsoluteFile();
-        log.info("workingDirectory = {}", workingDirectory.getAbsolutePath());
+                try {
+                    System.setProperty("file.encoding", "UTF-8");
+                    Field charset = Charset.class.getDeclaredField("defaultCharset");
+                    charset.setAccessible(true);
+                    charset.set(null, null);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    log.error("Exception", e);
+                }
 
-        // creation of GazePlay default folder if it does not exist.
-        File gazePlayFolder = new File(Utils.getGazePlayFolder());
-        if (!gazePlayFolder.exists()) {
-            boolean gazePlayFolderCreated = gazePlayFolder.mkdir();
-            log.info("gazePlayFolderCreated = " + gazePlayFolderCreated);
-        }
+                File workingDirectory = new File(".").getAbsoluteFile();
+                log.info("workingDirectory = {}", workingDirectory.getAbsolutePath());
 
-        Application.launch(GazePlay.class, args);
+                // creation of GazePlay default folder if it does not exist.
+                File gazePlayFolder = new File(Utils.getGazePlayFolder());
+                if (!gazePlayFolder.exists()) {
+                    boolean gazePlayFolderCreated = gazePlayFolder.mkdir();
+                    log.info("gazePlayFolderCreated = " + gazePlayFolderCreated);
+                }
+
+                Runnable runnable = () -> Application.launch(GazePlay.class, args);
+
+                ThreadFactory threadFactory = new CustomThreadFactory("javafx-bootsrap",
+                        new GroupingThreadFactory("javafx-bootsrap-group"));
+                Thread bootstrapThread = threadFactory.newThread(runnable);
+
+                if (doStartBootstrapThread) {
+                    bootstrapThread.start();
+                } else {
+                    try {
+                        Thread.sleep(1000 * 60 * 10);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+
+        ThreadFactory threadFactory = new CustomThreadFactory("application-bootsrap",
+                new GroupingThreadFactory("application-bootsrap-group"));
+        Thread bootstrapThread = threadFactory.newThread(runnable);
+        bootstrapThread.start();
     }
 
     private static String findVersionInfo(String applicationName) throws IOException {
@@ -79,11 +113,4 @@ public class GazePlayLauncher {
         return "Current Version";
     }
 
-    @Slf4j
-    private static class GazePlayUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
-        @Override
-        public void uncaughtException(Thread t, Throwable e) {
-            log.error("uncaughtException", e);
-        }
-    }
 }

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/Bravo.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/Bravo.java
@@ -12,6 +12,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import net.gazeplay.AsyncUiTaskExecutor;
 import net.gazeplay.commons.configuration.ConfigurationBuilder;
 import net.gazeplay.commons.utils.games.BackgroundMusicManager;
 
@@ -127,10 +128,7 @@ public class Bravo extends Rectangle {
             Platform.runLater(uiRunnable);
         };
 
-        Thread startPlayingThread = new Thread(deferedAnimationRunnable);
-
-        log.debug("Starting new thread ...");
-        startPlayingThread.start();
+        AsyncUiTaskExecutor.getInstance().getExecutorService().submit(deferedAnimationRunnable);
     }
 
     private SequentialTransition createFullTransition() {

--- a/gazeplay/src/main/java/net/gazeplay/games/drawonvideo/VideoPlayerWithLiveFeedbackApp.java
+++ b/gazeplay/src/main/java/net/gazeplay/games/drawonvideo/VideoPlayerWithLiveFeedbackApp.java
@@ -11,12 +11,17 @@ import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import net.gazeplay.GameContext;
 import net.gazeplay.GameLifeCycle;
+import net.gazeplay.commons.threads.GroupingThreadFactory;
 import net.gazeplay.commons.utils.stats.Stats;
 import net.gazeplay.games.draw.DrawBuilder;
 import net.gazeplay.games.draw.ProgressiveColorPicker;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class VideoPlayerWithLiveFeedbackApp implements GameLifeCycle {
 
@@ -41,6 +46,9 @@ public class VideoPlayerWithLiveFeedbackApp implements GameLifeCycle {
     private final Stats stats;
 
     private final WebView webview;
+
+    private final ExecutorService executorService = new ThreadPoolExecutor(1, 1, 3, TimeUnit.MINUTES,
+            new LinkedBlockingQueue<>(), new GroupingThreadFactory(this.getClass().getSimpleName()));
 
     public VideoPlayerWithLiveFeedbackApp(GameContext gameContext, Stats stats, String youtubeVideoId) {
         super();
@@ -169,9 +177,8 @@ public class VideoPlayerWithLiveFeedbackApp implements GameLifeCycle {
                 }
             }
         };
-        Thread canvasSwitchingThread = new Thread(canvasSwitchingTask);
 
-        canvasSwitchingThread.start();
+        executorService.execute(canvasSwitchingTask);
     }
 
     @Override


### PR DESCRIPTION
naming Threads so that logs (where each line contains the thread name) are more meaningful, also use Thread pool depending on usage.