### PR TITLE
NetBeans support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ target
 .settings
 gazeplay/*.log.*
 cache
+gazeplay/nbactions.xml
 

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/ImageDirectoryLocator.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/ImageDirectoryLocator.java
@@ -10,21 +10,26 @@ import java.net.URL;
 public class ImageDirectoryLocator {
 
     public static File locateImagesDirectoryInUnpackedDistDirectory(String parentImagesPackageResourceLocation) {
+        log.info("locateImagesDirectoryInUnpackedDistDirectory : parentImagesPackageResourceLocation = {}",
+                parentImagesPackageResourceLocation);
         final File workingDirectory = new File(".");
-        log.info("workingDirectory = {}", workingDirectory.getAbsolutePath());
+        log.info("locateImagesDirectoryInUnpackedDistDirectory : workingDirectory = {}",
+                workingDirectory.getAbsolutePath());
         final String workingDirectoryName;
         try {
             workingDirectoryName = workingDirectory.getCanonicalFile().getName();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        log.info("workingDirectoryName = {}", workingDirectoryName);
+        log.info("locateImagesDirectoryInUnpackedDistDirectory : workingDirectoryName = {}", workingDirectoryName);
 
-        log.info("parentImagesPackageResourceLocation = {}", parentImagesPackageResourceLocation);
+        log.info("locateImagesDirectoryInUnpackedDistDirectory : parentImagesPackageResourceLocation = {}",
+                parentImagesPackageResourceLocation);
 
         {
             final File imagesDirectory = new File(workingDirectory, parentImagesPackageResourceLocation);
-            log.info("imagesDirectory = {}", imagesDirectory.getAbsolutePath());
+            log.info("locateImagesDirectoryInUnpackedDistDirectory : imagesDirectory = {}",
+                    imagesDirectory.getAbsolutePath());
             boolean checked = checkImageDirectory(imagesDirectory);
             if (checked) {
                 return imagesDirectory;
@@ -33,7 +38,8 @@ public class ImageDirectoryLocator {
 
         if (workingDirectoryName.equals("bin")) {
             final File imagesDirectory = new File(workingDirectory, "../" + parentImagesPackageResourceLocation);
-            log.info("imagesDirectory = {}", imagesDirectory.getAbsolutePath());
+            log.info("locateImagesDirectoryInUnpackedDistDirectory : imagesDirectory = {}",
+                    imagesDirectory.getAbsolutePath());
             boolean checked = checkImageDirectory(imagesDirectory);
             if (checked) {
                 return imagesDirectory;

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/ImageUtils.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/ImageUtils.java
@@ -27,6 +27,11 @@ public class ImageUtils {
                 .locateImagesDirectoryInUnpackedDistDirectory("data/common/default/images/");
 
         if (defaultImageDirectory == null) {
+            defaultImageDirectory = ImageDirectoryLocator.locateImagesDirectoryInUnpackedDistDirectory(
+                    "gazeplay-data/src/main/resources/data/common/default/images/");
+        }
+
+        if (defaultImageDirectory == null) {
             defaultImageDirectory = ImageDirectoryLocator
                     .locateImagesDirectoryInExplodedClassPath("data/common/default/images/");
         }


### PR DESCRIPTION
In ```ImageDirectoryLocator```
Tests if an additional relative path (to working directory) exists as a directory.
If a directory exists with this path, then use it as an image directory.

This is a workaround for NetBeans that seems to set module classpath to JARs in maven local repository, where IntelliJ sets classpath to resources from other project's modules.

Should fix issue #359 
