### PR TITLE
Heat map

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
@@ -19,7 +19,7 @@ public class HeatMap {
     /**
      * Default colors, in case the default constructor is called
      */
-    private static final Color[] defaultColors = {Color.DARKBLUE, Color.GREEN, Color.YELLOW, Color.RED};
+    private static final Color[] defaultColors = { Color.DARKBLUE, Color.GREEN, Color.YELLOW, Color.RED };
 
     /**
      * Writable image used to create the heatmap image
@@ -44,39 +44,45 @@ public class HeatMap {
 
     /**
      * Default constructor, uses dark blue, green, yellow, and red as color variants.
-     * @param data monitor data
+     * 
+     * @param data
+     *            monitor data
      */
-    public HeatMap(double[][] data){
+    public HeatMap(double[][] data) {
         this(data, defaultColors);
     }
 
     /**
-     * Custom colors constructor, builds a heatmap from the given data, by interpolating the values through the given colors.
-     * @param data monitor data
-     * @param colors custom colors for the heatmap, must be on order from minimum to maximum.
+     * Custom colors constructor, builds a heatmap from the given data, by interpolating the values through the given
+     * colors.
+     * 
+     * @param data
+     *            monitor data
+     * @param colors
+     *            custom colors for the heatmap, must be on order from minimum to maximum.
      */
     public HeatMap(double[][] data, Color[] colors) {
         this.image = new WritableImage(data[0].length, data.length);
         this.colors = colors;
 
-        //Computing max and min values
+        // Computing max and min values
         minValue = Double.MAX_VALUE;
         maxValue = Double.MIN_VALUE;
-        for(int x = 0; x < data.length; x++){
-            for(int y = 0; y < data[x].length; y++){
-                if(data[x][y] > maxValue){
+        for (int x = 0; x < data.length; x++) {
+            for (int y = 0; y < data[x].length; y++) {
+                if (data[x][y] > maxValue) {
                     maxValue = data[x][y];
                 }
-                if(data[x][y] < minValue){
+                if (data[x][y] < minValue) {
                     minValue = data[x][y];
                 }
             }
         }
         subdivisionValue = (maxValue - minValue) / (this.colors.length - 1);
 
-        //Create heatmap pixel per pixel
+        // Create heatmap pixel per pixel
         PixelWriter pxWriter = image.getPixelWriter();
-        for(int x = 0; x < data.length; x++) {
+        for (int x = 0; x < data.length; x++) {
             for (int y = 0; y < data[x].length; y++) {
                 pxWriter.setColor(y, x, getColor(data[x][y]));
             }
@@ -85,27 +91,35 @@ public class HeatMap {
 
     /**
      * Computes the correct color of the value, by interpolating between the 2 colors in the right subdivision.
-     * @param value the value of the pixel (in data).
+     * 
+     * @param value
+     *            the value of the pixel (in data).
      * @return the resulting color after interpolation.
      */
-    private Color getColor(double value){
+    private Color getColor(double value) {
         double compValue = minValue + subdivisionValue;
-        int i = 0; //Once out of the loop, will be the index of the starting color of the interpolation
-        while(compValue < maxValue && value >= compValue){ //Finding the right subdivision, in order to get the colors between which the values is located
+        int i = 0; // Once out of the loop, will be the index of the starting color of the interpolation
+        while (compValue < maxValue && value >= compValue) { // Finding the right subdivision, in order to get the
+                                                             // colors between which the values is located
             i++;
             compValue += subdivisionValue;
         }
-        double red = Interpolator.LINEAR.interpolate(colors[i].getRed(), colors[i+1].getRed(), (value % subdivisionValue)/subdivisionValue);
-        double green = Interpolator.LINEAR.interpolate(colors[i].getGreen(), colors[i+1].getGreen(), (value % subdivisionValue)/subdivisionValue);
-        double blue = Interpolator.LINEAR.interpolate(colors[i].getBlue(), colors[i+1].getBlue(), (value % subdivisionValue)/subdivisionValue);
+        double red = Interpolator.LINEAR.interpolate(colors[i].getRed(), colors[i + 1].getRed(),
+                (value % subdivisionValue) / subdivisionValue);
+        double green = Interpolator.LINEAR.interpolate(colors[i].getGreen(), colors[i + 1].getGreen(),
+                (value % subdivisionValue) / subdivisionValue);
+        double blue = Interpolator.LINEAR.interpolate(colors[i].getBlue(), colors[i + 1].getBlue(),
+                (value % subdivisionValue) / subdivisionValue);
         return Color.color(red, green, blue);
     }
 
     /**
      * Saves the heatmap to a PNG file
-     * @param outputFile The output file (Must be open and writable)
+     * 
+     * @param outputFile
+     *            The output file (Must be open and writable)
      */
-    public void saveToFile(File outputFile){
+    public void saveToFile(File outputFile) {
         BufferedImage bImage = SwingFXUtils.fromFXImage(image, null);
         try {
             ImageIO.write(bImage, "png", outputFile);

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
@@ -90,8 +90,8 @@ public class HeatMap {
      */
     private Color getColor(double value){
         double compValue = minValue + subdivisionValue;
-        int i = 0;
-        while(compValue < maxValue && value >= compValue){
+        int i = 0; //Once out of the loop, will be the index of the starting color of the interpolation
+        while(compValue < maxValue && value >= compValue){ //Finding the right subdivision, in order to get the colors between which the values is located
             i++;
             compValue += subdivisionValue;
         }

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/HeatMap.java
@@ -1,0 +1,85 @@
+package net.gazeplay.commons.utils;
+
+import javafx.animation.Interpolator;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.effect.GaussianBlur;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+import javafx.scene.paint.Color;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Creates a heatmap image from a given 2D array
+ */
+public class HeatMap {
+
+    /**
+     * Max value in the data.
+     * Used for interpolation.
+     */
+    private double maxValue;
+    /**
+     * Min value in the data.
+     * Used for interpolation.
+     */
+    private double minValue;
+    /**
+     * Mid-point value in the data.
+     * Used for interpolation (3 colors).
+     */
+    private double midValue;
+
+    private WritableImage image;
+
+    public HeatMap(double[][] data) {
+        image = new WritableImage(data[0].length, data.length);
+
+        //Computing max and min values
+        minValue = Double.MAX_VALUE;
+        maxValue = Double.MIN_VALUE;
+        for(int x = 0; x < data.length; x++){
+            for(int y = 0; y < data[x].length; y++){
+                if(data[x][y] > maxValue){
+                    maxValue = data[x][y];
+                }
+                if(data[x][y] < minValue){
+                    minValue = data[x][y];
+                }
+            }
+        }
+        midValue = (minValue + maxValue) / 2.0;
+
+        PixelWriter pxWriter = image.getPixelWriter();
+
+        for(int x = 0; x < data.length; x++) {
+            for (int y = 0; y < data[x].length; y++) {
+                pxWriter.setColor(y, x, getColor(data[x][y]));
+            }
+        }
+
+
+    }
+
+    private Color getColor(double value){
+        if(value < maxValue * 0.1){
+            return Color.BLUE;
+        }else {
+            double red = value >= midValue ? 1.0 : Interpolator.LINEAR.interpolate(0.0, 1.0, value / midValue);
+            double green = value < midValue ? 1.0 : Interpolator.LINEAR.interpolate(0.0, 1.0, (value - midValue) / midValue);
+            return Color.color(red, green, 0.0);
+        }
+    }
+
+    public void saveToFile(File outputFile){
+        BufferedImage bImage = SwingFXUtils.fromFXImage(image, null);
+        try {
+            ImageIO.write(bImage, "png", outputFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.gazeplay.commons.configuration.Configuration;
 import net.gazeplay.commons.gaze.GazeMotionListener;
 import net.gazeplay.commons.gaze.devicemanager.GazeEvent;
+import net.gazeplay.commons.utils.HeatMap;
 import net.gazeplay.commons.utils.games.Utils;
 import org.tc33.jheatchart.HeatChart;
 
@@ -204,15 +205,7 @@ public class Stats implements GazeMotionListener {
 
         log.info(String.format("Heatmap size: %3d X %3d", heatMap[0].length, heatMap.length));
 
-        // Step 1: Create our heat map chart using our data.
-        HeatChart map = new HeatChart(heatMap);
-
-        map.setHighValueColour(java.awt.Color.RED);
-        map.setLowValueColour(java.awt.Color.lightGray);
-
-        map.setShowXAxisValues(false);
-        map.setShowYAxisValues(false);
-        map.setChartMargin(0);
+        HeatMap map = new HeatMap(heatMap);
 
         try {
             map.saveToFile(outputPngFile);

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
@@ -11,6 +11,7 @@ import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
+import javafx.scene.effect.GaussianBlur;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
@@ -144,6 +145,7 @@ public class StatsDisplay {
         });
 
         heatMap.setImage(new Image(savedStatsInfo.getHeatMapPngFile().toURI().toString()));
+        heatMap.setEffect(new GaussianBlur());
 
         EventHandler<Event> openHeatMapEvent = createZoomInHeatMapEventHandler(heatMap, root);
         heatMap.addEventHandler(MouseEvent.MOUSE_CLICKED, openHeatMapEvent);

--- a/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
+++ b/gazeplay/src/main/java/net/gazeplay/commons/utils/stats/StatsDisplay.java
@@ -145,7 +145,9 @@ public class StatsDisplay {
         });
 
         heatMap.setImage(new Image(savedStatsInfo.getHeatMapPngFile().toURI().toString()));
-        heatMap.setEffect(new GaussianBlur());
+        GaussianBlur blur = new GaussianBlur();
+        blur.setRadius(10.0);
+        heatMap.setEffect(blur);
 
         EventHandler<Event> openHeatMapEvent = createZoomInHeatMapEventHandler(heatMap, root);
         heatMap.addEventHandler(MouseEvent.MOUSE_CLICKED, openHeatMapEvent);


### PR DESCRIPTION
This is my solution to issue [#114](https://github.com/schwabdidier/GazePlay/issues/114).

I created a class, named HeatMap, which is located in the HeatMap.java file in gazeplay-commons (it could be moved to a more suitable place, the current location was chosen by my IDE automatically).
This class creates an image of a heat map from the data generated in Stats.java.
It uses interpolation in a list of colors, to create gradients of colors, and can use as many colors as possible (or as few).
You can use custom colors (if an array of colors is given to the constructor) if you ever need to; I was thinking about using a special color scheme for color-blind people for example.
I then added a Gaussian blur effect to the ImageView object containing the heat map so it can look better.

Here's the resulting file after playing a game of Bubbles:
![heat map png](https://user-images.githubusercontent.com/19331032/52063631-4627f000-2573-11e9-869f-bcef28734574.png)
And the same heat map, in the end game stat window (with the blur effect):
![screenshot](https://user-images.githubusercontent.com/19331032/52063892-c9e1dc80-2573-11e9-8ec0-ee1fb0547fcd.png)

The code is formatted using **mvn clean install -T 1C**