### PR TITLE
Added shots ratio for bubble games [TRAVIS VALIDATED]

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
@@ -158,6 +158,7 @@ public class Stats implements GazeMotionListener {
             this.roundsDurationReport.addRoundDuration(currentRoundDuration);
         }
         currentRoundStartTime = currentRoundEndTime;
+        System.out.println("The number of goals is "+ nbGoals +"and the number shots is "+ nbShots);
     }
 
 

--- a/gazeplay/src/main/java/net/gazeplay/StatsContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/StatsContext.java
@@ -93,8 +93,15 @@ public class StatsContext extends GraphicalContext<BorderPane> {
             } else {
                 label = new I18NText(translator, "Score", COLON);
             }
+            Text value;
+            if(stats instanceof BubblesGamesStats)
+            {
+                value = new Text(String.valueOf(stats.getNbGoals()/2));
 
-            Text value = new Text(String.valueOf(stats.getNbGoals()));
+            }else{
+                value = new Text(String.valueOf(stats.getNbGoals()));
+
+            }
 
             if (!(stats instanceof ExplorationGamesStats)) {
                 addToGrid(grid, currentFormRow, label, value);
@@ -103,7 +110,7 @@ public class StatsContext extends GraphicalContext<BorderPane> {
         }
         {
             final I18NText label;
-            if (stats instanceof ShootGamesStats) {
+            if (stats instanceof ShootGamesStats ||stats instanceof BubblesGamesStats) {
                 label = new I18NText(translator, "ShotsRates", COLON);
                 Text value = new Text(String.valueOf(stats.getShotRatio() +"%"));
                 if (!(stats instanceof ExplorationGamesStats)) {

--- a/gazeplay/src/main/java/net/gazeplay/games/bubbles/Bubble.java
+++ b/gazeplay/src/main/java/net/gazeplay/games/bubbles/Bubble.java
@@ -204,6 +204,7 @@ public class Bubble extends Parent implements GameLifeCycle {
         target.removeEventFilter(GazeEvent.ANY, enterEvent);
 
         explose(Xcenter, Ycenter); // instead of C to avoid wrong position of the explosion
+        stats.incNbGoals();
     }
 
     private void newCircle() {
@@ -233,6 +234,8 @@ public class Bubble extends Parent implements GameLifeCycle {
             C.setFill(new Color(Math.random(), Math.random(), Math.random(), 0.9));
         else
             C.setFill(new ImagePattern(imageLibrary.pickRandomImage(), 0, 0, 1, 1, true));
+        stats.incNbShots();
+        stats.incNbShots();
 
         return C;
     }


### PR DESCRIPTION
This push is a follow up of problem #611. I have added the shoot ratio tracking for the bubble game. I would like to note that there is a bug when the user enters a bubble, the number of goals is incremented twice. For now, I have worked around this issue to implement the ratio for the bubble game.