### PR TITLE
Fixed sound occasionally not playing for ninja game

### DIFF
--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/Utils.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/games/Utils.java
@@ -25,7 +25,7 @@ public class Utils {
 
     public static final String FILESEPARATOR = System.getProperties().getProperty("file.separator");
     public static final String LINESEPARATOR = System.getProperties().getProperty("line.separator");
-
+    private static MediaPlayer sxmp;
     private static final String tempFolder = "temp";
 
     public static MenuBar buildLicence() {
@@ -76,14 +76,15 @@ public class Utils {
         }
 
         log.debug("path " + path);
-
+        if (sxmp != null)
+            sxmp.stop();
         try {
             Media media = new Media(path);
-            MediaPlayer mp = new MediaPlayer(media);
+            sxmp = new MediaPlayer(media);
             final Configuration configuration = Configuration.getInstance();
-            mp.setVolume(configuration.getEffectsVolume());
-            mp.volumeProperty().bind(configuration.getEffectsVolumeProperty());
-            mp.play();
+            sxmp.setVolume(configuration.getEffectsVolume());
+            sxmp.volumeProperty().bind(configuration.getEffectsVolumeProperty());
+            sxmp.play();
         } catch (Exception e) {
             log.error("Exception", e);
         }

--- a/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
+++ b/gazeplay-commons/src/main/java/net/gazeplay/commons/utils/stats/Stats.java
@@ -158,7 +158,7 @@ public class Stats implements GazeMotionListener {
             this.roundsDurationReport.addRoundDuration(currentRoundDuration);
         }
         currentRoundStartTime = currentRoundEndTime;
-        System.out.println("The number of goals is "+ nbGoals +"and the number shots is "+ nbShots);
+        System.out.println("The number of goals is " + nbGoals + "and the number shots is " + nbShots);
     }
 
     public int getShotRatio() {

--- a/gazeplay/src/main/java/net/gazeplay/StatsContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/StatsContext.java
@@ -94,11 +94,10 @@ public class StatsContext extends GraphicalContext<BorderPane> {
                 label = new I18NText(translator, "Score", COLON);
             }
             Text value;
-            if(stats instanceof BubblesGamesStats)
-            {
-                value = new Text(String.valueOf(stats.getNbGoals()/2));
+            if (stats instanceof BubblesGamesStats) {
+                value = new Text(String.valueOf(stats.getNbGoals() / 2));
 
-            }else{
+            } else {
                 value = new Text(String.valueOf(stats.getNbGoals()));
 
             }
@@ -110,7 +109,7 @@ public class StatsContext extends GraphicalContext<BorderPane> {
         }
         {
             final I18NText label;
-            if (stats instanceof ShootGamesStats ||stats instanceof BubblesGamesStats) {
+            if (stats instanceof ShootGamesStats || stats instanceof BubblesGamesStats) {
                 label = new I18NText(translator, "ShotsRates", COLON);
                 Text value = new Text(String.valueOf(stats.getShotRatio() + "%"));
                 if (!(stats instanceof ExplorationGamesStats)) {


### PR DESCRIPTION
This request reference problem #526 
I have speculated that new sounds are constantly played and overlapping the previous sound too quickly when we cut an object in the game ninja. The previous sound has not ended while a new one has come. Thus I stop the media player before playing a new sound in order to resolve this issue.

I have tested around 50 rounds of the ninja game and the sound issue seems to be resolved.