### PR TITLE
Aoi performance improvement

### DIFF
--- a/gazeplay/src/main/java/net/gazeplay/AreaOfInterest.java
+++ b/gazeplay/src/main/java/net/gazeplay/AreaOfInterest.java
@@ -176,8 +176,7 @@ public class AreaOfInterest extends GraphicalContext<BorderPane> {
                 areaOfInterestList = new ArrayList<>();
             }
         }
-        if (index != movementHistory.size() - 1)
-            calculateAreaOfInterest(index + 1, startTime);
+
     }
 
     private InfoBoxProps calculateInfoBox(String aoiID, long TTFF, long TimeSpent, long Fixation, int centerX,
@@ -300,7 +299,8 @@ public class AreaOfInterest extends GraphicalContext<BorderPane> {
         areaOfInterestList = new ArrayList<>();
         movementHistory = stats.getMovementHistoryWithTime();
         System.out.println("The start time is " + stats.getStartTime());
-        calculateAreaOfInterest(0, stats.getStartTime());
+        for(int i = 0 ; i < movementHistory.size();i++)
+        calculateAreaOfInterest(i, stats.getStartTime());
         System.out.println("The amount of AOIs is " + allAOIList.size());
 
         areaMap = new int[allAOIList.size()];

--- a/gazeplay/src/main/java/net/gazeplay/AreaOfInterest.java
+++ b/gazeplay/src/main/java/net/gazeplay/AreaOfInterest.java
@@ -55,9 +55,9 @@ public class AreaOfInterest extends GraphicalContext<BorderPane> {
     private int progressRate = 1;
     private Double previousInfoBoxX;
     private Double previousInfoBoxY;
-    private ArrayList<InitialAreaOfInterestProps> combinedAreaList = new ArrayList<>();;
+    private ArrayList<InitialAreaOfInterestProps> combinedAreaList;;
     private double combinationThreshHold = 0.70;
-    int[] areaMap;
+    private int[] areaMap;
 
     @Override
     public ObservableList<Node> getChildren() {
@@ -299,8 +299,8 @@ public class AreaOfInterest extends GraphicalContext<BorderPane> {
         areaOfInterestList = new ArrayList<>();
         movementHistory = stats.getMovementHistoryWithTime();
         System.out.println("The start time is " + stats.getStartTime());
-        for(int i = 0 ; i < movementHistory.size();i++)
-        calculateAreaOfInterest(i, stats.getStartTime());
+        for (int i = 0; i < movementHistory.size(); i++)
+            calculateAreaOfInterest(i, stats.getStartTime());
         System.out.println("The amount of AOIs is " + allAOIList.size());
 
         areaMap = new int[allAOIList.size()];


### PR DESCRIPTION
I have noticed a stackOverFlowError on window machines and other machines with a small memory capacity that is caused by the recursive method used to calculate the AOI.
I have changed it to a loop instead.

Sorry for any inconveniences.
