### PR TITLE
Fix issues with generated distrib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
 String value = project.getProperties().get('SpotBugs')
 boolean SpotBugs = Boolean.parseBoolean(value) ?: true
 
-String javafxVersion = "11.0.2"
+ext.javafxVersion = "11.0.2"
 
 allprojects {
     group = 'com.github.schwabdidier'
@@ -80,6 +80,8 @@ subprojects {
 
     sourceCompatibility = '11'
 
+
+
     publishing {
         publications {
             maven(MavenPublication) {
@@ -129,19 +131,6 @@ distributions {
     }
 }
 
-jar {
-    manifest {
-        attributes(
-                "Implementation-Title": project.name,
-                "Implementation-Version": project.version,
-                "Implementation-Vendor": "Univ. Grenoble Alpes - LIG - GETALP",
-                "Main-Class": 'net.gazeplay.GazePlayLauncher',
-                "Class-Path": configurations.runtime.collect { it.getName() }.join(' '),
-                "JavaFX-Version": javafxVersion,
-                "Built-By": System.properties['user.name']
-        )
-    }
-}
 
 runtime {
     options = ['--compress', '2', '--no-header-files', '--no-man-pages']

--- a/gazeplay-commons/build.gradle
+++ b/gazeplay-commons/build.gradle
@@ -17,3 +17,16 @@ dependencies {
     runtime 'io.github.classgraph:classgraph:4.8.52'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.2.1.RELEASE'
 }
+
+jar {
+    manifest {
+        attributes(
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": "Univ. Grenoble Alpes - LIG - GETALP",
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' '),
+                "JavaFX-Version": javafxVersion,
+                "Built-By": System.properties['user.name']
+        )
+    }
+}

--- a/gazeplay-dist/src/main/bin/gazeplay-linux.sh
+++ b/gazeplay-dist/src/main/bin/gazeplay-linux.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAIN_JAR_FILE=@NAME@-@VERSION@.jar
+MAIN_JAR_FILE=gazeplay-@VERSION@.jar
 
 export JAVA_OPTS="-Xms256m -Xmx1g"
 
@@ -22,7 +22,9 @@ LIB_DIR_RELATIVE=$(realpath --relative-to="${WORKING_DIR}" "${LIB_DIR}")
 
 echo "LIB_DIR_RELATIVE = ${LIB_DIR_RELATIVE}"
 
-export JAVA_CMD="java ${JAVA_OPTS} -jar ${LIB_DIR_RELATIVE}/${MAIN_JAR_FILE}" 
+CLASSPATH=$(find ./$LIB_DIR_RELATIVE -name "*.jar" | sort | tr '\n' ':')
+
+export JAVA_CMD="java -cp \"$CLASSPATH\" ${JAVA_OPTS} net.gazeplay.GazePlayLauncher" 
 
 echo "Executing command line: $JAVA_CMD"
 

--- a/gazeplay-dist/src/main/bin/gazeplay-macos.sh
+++ b/gazeplay-dist/src/main/bin/gazeplay-macos.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAIN_JAR_FILE=@NAME@-@VERSION@.jar
+MAIN_JAR_FILE=gazeplay-@VERSION@.jar
 
 export JAVA_OPTS="-Xms256m -Xmx1g"
 

--- a/gazeplay-dist/src/main/bin/gazeplay-win10.bat
+++ b/gazeplay-dist/src/main/bin/gazeplay-win10.bat
@@ -2,7 +2,7 @@
 
 SET PATH=%PATH%;%LocalAppData%\TobiiStreamEngineForJava\lib\tobii\x64
 
-..\lib\jre\bin\java -Xms256m -Xmx1g -jar ..\lib\@NAME@-@VERSION@.jar
+..\lib\jre\bin\java -Xms256m -Xmx1g -jar ..\lib\gazeplay-@VERSION@.jar
 
 REM prints a nice "Press any key to continue . . . " message
 pause

--- a/gazeplay-dist/src/main/bin/gazeplay.bat
+++ b/gazeplay-dist/src/main/bin/gazeplay.bat
@@ -2,7 +2,7 @@
 
 SET PATH=%PATH%;%LocalAppData%\TobiiStreamEngineForJava\lib\tobii\x64
 
-java -Xms256m -Xmx1g -jar ..\lib\@NAME@-@VERSION@.jar
+java -Xms256m -Xmx1g -jar ..\lib\gazeplay-@VERSION@.jar
 
 
 REM prints a nice "Press any key to continue . . . " message

--- a/gazeplay-games-commons/build.gradle
+++ b/gazeplay-games-commons/build.gradle
@@ -25,3 +25,18 @@ dependencies {
 //        }
 //    }
 //}
+
+
+jar {
+    manifest {
+        attributes(
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": "Univ. Grenoble Alpes - LIG - GETALP",
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' '),
+                "JavaFX-Version": javafxVersion,
+                "Built-By": System.properties['user.name']
+        )
+    }
+}
+

--- a/gazeplay-games/build.gradle
+++ b/gazeplay-games/build.gradle
@@ -26,3 +26,17 @@ dependencies {
 //        }
 //    }
 //}
+
+
+jar {
+    manifest {
+        attributes(
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": "Univ. Grenoble Alpes - LIG - GETALP",
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' '),
+                "JavaFX-Version": javafxVersion,
+                "Built-By": System.properties['user.name']
+        )
+    }
+}

--- a/gazeplay/build.gradle
+++ b/gazeplay/build.gradle
@@ -30,3 +30,17 @@ dependencies {
 //        }
 //    }
 //}
+
+jar {
+    manifest {
+        attributes(
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": "Univ. Grenoble Alpes - LIG - GETALP",
+                "Main-Class": 'net.gazeplay.GazePlayLauncher',
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' '),
+                "JavaFX-Version": javafxVersion,
+                "Built-By": System.properties['user.name']
+        )
+    }
+}


### PR DESCRIPTION
Fixed all JARs generated MANIFEST.MF. 
Fixed Linux launcher .sh script.
Fixed jar name in Windows and Mac launcher scripts.

Distrib now works on GNU/Linux, just unzip then execute ./bin/gazeplay-linux.sh

Not tested on Windows or Mac yet.