### PR TITLE
should fix #907 (works also for right alignment language like Arabic)

### DIFF
--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorBox.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorBox.java
@@ -3,6 +3,7 @@ package net.gazeplay.games.colors;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventHandler;
+import javafx.geometry.Insets;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.input.MouseEvent;
@@ -28,6 +29,8 @@ public class ColorBox extends StackPane {
 
     public static final double COLOR_BOX_HEIGHT_REDUCTION_COEFF = 1.3;
 
+    public static final double COLOR_BOX_PADDING = 5;
+
     @Setter
     private AbstractGazeIndicator progressIndicator;
 
@@ -45,6 +48,7 @@ public class ColorBox extends StackPane {
 
         button = new ToggleButton();
         //button.setToggleGroup(group);
+        button.setPadding( new Insets(COLOR_BOX_PADDING,COLOR_BOX_PADDING,COLOR_BOX_PADDING,COLOR_BOX_PADDING));
 
         graphic = new Rectangle(COLOR_BOX_WIDTH_PX, computeHeight(), color);
         // graphic = new Circle(COLOR_CIRCLE_RADIUS);
@@ -54,7 +58,7 @@ public class ColorBox extends StackPane {
 
         this.color = color;
 
-        root.heightProperty().addListener((observable) -> {
+        toolBox.heightProperty().addListener((observable) -> {
 
             double newHeight = this.computeHeight();
             // log.info("new Height = {}", newHeight);
@@ -72,6 +76,10 @@ public class ColorBox extends StackPane {
         toolBox.getColorsGame().getGameContext().getGazeDeviceManager().addEventFilter(this);
     }
 
+    public void updateHeight(){
+        graphic.setHeight(computeHeight());
+    }
+
     /**
      * Automatically compute free space in the tool box.
      * 
@@ -82,15 +90,15 @@ public class ColorBox extends StackPane {
         javafx.geometry.Dimension2D dimension2D = toolBox.getColorsGame().getGameContext()
                 .getGamePanelDimensionProvider().getDimension2D();
 
-        double totalHeight = dimension2D.getHeight() * ColorToolBox.HEIGHT_POURCENT;
+        double totalHeight = dimension2D.getHeight();
 
         // Compute free space taking into account every elements in the tool box
-        double freeSpace = totalHeight - (ColorToolBox.MAIN_INSETS.getTop() + ColorToolBox.MAIN_INSETS.getBottom()
-                + ColorToolBox.SPACING_PX*3 + toolBox.getImageManager().getHeight())
-                + toolBox.getColorziationPane().getBoundsInLocal().getHeight();
+        double freeSpace = totalHeight - ( (ColorToolBox.SPACING_PX + 2* COLOR_BOX_PADDING) * (5 + 1) + toolBox.getImageManager().getBoundsInLocal().getHeight()
+                + toolBox.getColorziationPane().getBoundsInLocal().getHeight() + ColorToolBox.COLORIZE_BUTTONS_SIZE_PX) -COLOR_BOX_PADDING*2;
+
 
         // + 1 for the curstom color box
-        return freeSpace / ((ColorToolBox.NB_COLORS_DISPLAYED + 1) * COLOR_BOX_HEIGHT_REDUCTION_COEFF);
+        return freeSpace / (ColorToolBox.NB_COLORS_DISPLAYED + 1);
     }
 
     public void select() {

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorBox.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorBox.java
@@ -25,7 +25,6 @@ public class ColorBox extends StackPane {
     private final ColorToolBox toolBox;
 
     public static final double COLOR_BOX_WIDTH_PX = 200;
-    public static final double COLOR_CIRCLE_RADIUS = 2;
 
     public static final double COLOR_BOX_HEIGHT_REDUCTION_COEFF = 1.3;
 
@@ -45,7 +44,7 @@ public class ColorBox extends StackPane {
         progressIndicator = toolBox.getProgressIndicator();
 
         button = new ToggleButton();
-        button.setToggleGroup(group);
+        //button.setToggleGroup(group);
 
         graphic = new Rectangle(COLOR_BOX_WIDTH_PX, computeHeight(), color);
         // graphic = new Circle(COLOR_CIRCLE_RADIUS);
@@ -87,24 +86,8 @@ public class ColorBox extends StackPane {
 
         // Compute free space taking into account every elements in the tool box
         double freeSpace = totalHeight - (ColorToolBox.MAIN_INSETS.getTop() + ColorToolBox.MAIN_INSETS.getBottom()
-                + ColorToolBox.SPACING_PX + toolBox.getImageManager().getHeight())
-                + toolBox.getColorziationPane().getHeight();
-
-        // + 1 for the curstom color box
-        return freeSpace / ((ColorToolBox.NB_COLORS_DISPLAYED + 1) * COLOR_BOX_HEIGHT_REDUCTION_COEFF);
-    }
-
-    private double computeRadius() {
-
-        javafx.geometry.Dimension2D dimension2D = toolBox.getColorsGame().getGameContext()
-                .getGamePanelDimensionProvider().getDimension2D();
-
-        double totalHeight = dimension2D.getHeight() * ColorToolBox.HEIGHT_POURCENT;
-
-        // Compute free space taking into account every elements in the tool box
-        double freeSpace = totalHeight - (ColorToolBox.MAIN_INSETS.getTop() + ColorToolBox.MAIN_INSETS.getBottom()
-                + ColorToolBox.SPACING_PX + toolBox.getImageManager().getHeight())
-                + toolBox.getColorziationPane().getHeight();
+                + ColorToolBox.SPACING_PX*3 + toolBox.getImageManager().getHeight())
+                + toolBox.getColorziationPane().getBoundsInLocal().getHeight();
 
         // + 1 for the curstom color box
         return freeSpace / ((ColorToolBox.NB_COLORS_DISPLAYED + 1) * COLOR_BOX_HEIGHT_REDUCTION_COEFF);

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorToolBox.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorToolBox.java
@@ -126,7 +126,7 @@ public class ColorToolBox extends StackPane {
         mainPane = new VBox();
         thisRoot.setCenter(mainPane);
         mainPane.setSpacing(SPACING_PX);
-        mainPane.setPadding(MAIN_INSETS);
+       // mainPane.setPadding(MAIN_INSETS);
 
         imageManager = buildImageManager();
         colorziationPane = buildColorizationPane();

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorToolBox.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorToolBox.java
@@ -33,17 +33,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
-public class ColorToolBox extends StackPane {
+public class ColorToolBox extends Pane {
 
     /**
      * Pourcents use to compute height and width.
      */
-    public static final double WIDTH_POURCENT = 0.10;
-    public static final double HEIGHT_POURCENT = 0.80;
 
     public static final double SPACING_PX = 10;
 
-    public static final Insets MAIN_INSETS = new Insets(10, 15, 10, 15);
+    //public static final Insets MAIN_INSETS = new Insets(10, 15, 10, 15);
 
     /**
      * The size of the next and previous
@@ -74,6 +72,7 @@ public class ColorToolBox extends StackPane {
     /**
      * All the color boxes
      */
+    @Getter
     private final List<ColorBox> colorBoxes;
 
     /**
@@ -130,6 +129,9 @@ public class ColorToolBox extends StackPane {
 
         imageManager = buildImageManager();
         colorziationPane = buildColorizationPane();
+
+        thisRoot.setBottom(imageManager);
+        thisRoot.setTop(colorziationPane);
 
         ColorBox colorBox;
         EventHandler<Event> eventHandler;
@@ -213,7 +215,6 @@ public class ColorToolBox extends StackPane {
              * customColorButtonIndic.getWidth(), customColorButtonIndic.getHeight());
              */
             colorsGame.setEnableColorization(previousEnableColor);
-
         });
 
         colorPicker.setOnAction((event) -> customBox.setColor(colorPicker.getValue()));
@@ -255,14 +256,14 @@ public class ColorToolBox extends StackPane {
          * this.setRight(nextPallet); this.setLeft(previousPallet);
          */
 
-        thisRoot.setBottom(imageManager);
-        thisRoot.setTop(colorziationPane);
         root.getChildren().add(customColorButtonIndic);
 
         if (!gameContext.getConfiguration().isBackgroundWhite()) {
 
             this.getStyleClass().add("bg-colored");
         }
+
+
     }
 
     private Pane buildImageManager() {
@@ -270,7 +271,7 @@ public class ColorToolBox extends StackPane {
         Stage primaryStage = gameContext.getPrimaryStage();
 
         final HBox bottomBox = new HBox(7);
-        bottomBox.setPadding(new Insets(0, 5, 2, 5));
+        bottomBox.setPadding(new Insets(0, 5, 0, 5));
 
         final FileChooser imageChooser = new FileChooser();
         configureImageFileChooser(imageChooser);

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorsGame.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorsGame.java
@@ -15,6 +15,7 @@ import javafx.scene.image.PixelReader;
 import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.ImagePattern;
@@ -121,7 +122,7 @@ public class ColorsGame implements GameLifeCycle {
 
     private final ColorsGamesStats stats;
 
-    private final TitledPane toolBoxPane;
+    private final BorderPane toolBoxPane;
 
     private final Translator translator;
 
@@ -132,7 +133,7 @@ public class ColorsGame implements GameLifeCycle {
 
         root = gameContext.getRoot();
 
-        toolBoxPane = new TitledPane(translator.translate("Colors!"), colorToolBox);
+        toolBoxPane = new BorderPane(colorToolBox);
 
         drawingEnable.addListener((observable, oldValue, newValue) -> {
             // If we want to stop colorization
@@ -179,10 +180,7 @@ public class ColorsGame implements GameLifeCycle {
     private void buildToolBox(double width, double height) {
 
         this.colorToolBox = new ColorToolBox(this.root, this, gameContext);
-        toolBoxPane.setContent(colorToolBox);
-
-        toolBoxPane.setCollapsible(false);
-        toolBoxPane.setAnimated(false);
+        toolBoxPane.setCenter(colorToolBox);
 
         this.root.getChildren().add(toolBoxPane);
 

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorsGame.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/ColorsGame.java
@@ -122,8 +122,6 @@ public class ColorsGame implements GameLifeCycle {
 
     private final ColorsGamesStats stats;
 
-    private final BorderPane toolBoxPane;
-
     private final Translator translator;
 
     ColorsGame(IGameContext gameContext, final ColorsGamesStats stats, final Translator translator) {
@@ -132,8 +130,6 @@ public class ColorsGame implements GameLifeCycle {
         this.translator = translator;
 
         root = gameContext.getRoot();
-
-        toolBoxPane = new BorderPane(colorToolBox);
 
         drawingEnable.addListener((observable, oldValue, newValue) -> {
             // If we want to stop colorization
@@ -164,10 +160,13 @@ public class ColorsGame implements GameLifeCycle {
         double width = dimension2D.getWidth();
         double height = dimension2D.getHeight();
 
+
         buildToolBox(width, height);
 
         // log.info("Toolbox width = {}, height = {}", colorToolBox.getWidth(), colorToolBox.getHeight());
         buildDraw(DEFAULT_IMAGE, width, height);
+
+        colorToolBox.getColorBoxes().forEach(ColorBox::updateHeight);
 
         stats.notifyNewRoundReady();
     }
@@ -180,9 +179,7 @@ public class ColorsGame implements GameLifeCycle {
     private void buildToolBox(double width, double height) {
 
         this.colorToolBox = new ColorToolBox(this.root, this, gameContext);
-        toolBoxPane.setCenter(colorToolBox);
-
-        this.root.getChildren().add(toolBoxPane);
+        this.root.getChildren().add(colorToolBox);
 
         // Add it here so it appears on top of the tool box
         final AbstractGazeIndicator progressIndicator = colorToolBox.getProgressIndicator();
@@ -191,8 +188,9 @@ public class ColorsGame implements GameLifeCycle {
 
         updateToolBox();
 
-        toolBoxPane.maxHeightProperty().bind(gameContext.getRoot().heightProperty());
-        toolBoxPane.prefHeightProperty().bind(gameContext.getRoot().heightProperty());
+        colorToolBox.maxHeightProperty().bind(gameContext.getRoot().heightProperty());
+        colorToolBox.prefHeightProperty().bind(gameContext.getRoot().heightProperty());
+        colorToolBox.minHeightProperty().bind(gameContext.getRoot().heightProperty());
     }
 
     private void buildDraw(String imgURL, double width, double height) {
@@ -273,10 +271,10 @@ public class ColorsGame implements GameLifeCycle {
 
         double width = dimension2D.getWidth();
 
-        double ToolBoxWidth = toolBoxPane.getWidth();
+        double ToolBoxWidth = colorToolBox.getWidth();
         double x = width - ToolBoxWidth;
         log.debug("translated tool box to : {}, x toolBoxWidth : {}", x, ToolBoxWidth);
-        toolBoxPane.setTranslateX(x);
+        colorToolBox.setTranslateX(x);
     }
 
     /**

--- a/gazeplay-games/src/main/java/net/gazeplay/games/colors/GazeFollowerIndicator.java
+++ b/gazeplay-games/src/main/java/net/gazeplay/games/colors/GazeFollowerIndicator.java
@@ -49,7 +49,6 @@ public class GazeFollowerIndicator extends AbstractGazeIndicator {
     }
 
     private void moveGazeIndicator(double x, double y) {
-        System.out.println("moving gaze");
         this.setTranslateX(x - (GAZE_PROGRESS_INDICATOR_WIDTH) / 2);
         this.setTranslateY(y + GAZE_PROGRESS_INDICATOR_OFFSET - GAZE_PROGRESS_INDICATOR_HEIGHT / 2);
 

--- a/gazeplay/src/main/java/net/gazeplay/ui/scenes/stats/StatsContext.java
+++ b/gazeplay/src/main/java/net/gazeplay/ui/scenes/stats/StatsContext.java
@@ -107,10 +107,10 @@ public class StatsContext extends GraphicalContext<BorderPane> {
         Configuration config = ActiveConfigurationContext.getInstance();
 
         GridPane grid = new GridPane();
-        grid.setAlignment(Pos.CENTER);
+        grid.setAlignment(Pos.TOP_CENTER);
         grid.setHgap(100);
         grid.setVgap(50);
-        grid.setPadding(new Insets(50, 50, 50, 50));
+        grid.setPadding(new Insets(0, 50, 0, 50));
 
         AtomicInteger currentFormRow = new AtomicInteger(1);
         {
@@ -282,13 +282,20 @@ public class StatsContext extends GraphicalContext<BorderPane> {
         topPane.getChildren().add(screenTitleText);
 
         root.setTop(topPane);
+
+        BorderPane sidePane = new BorderPane();
+
         if (alignLeft) {
+            sidePane.setTop(centerStackPane);
+            root.setCenter(sidePane);
             root.setLeft(grid);
         } else { // Arabic alignment
-            root.setRight(grid);
+            sidePane.setTop(grid);
+            root.setCenter(centerStackPane);
+            root.setRight(sidePane);
         }
-        root.setCenter(centerStackPane);
-        root.setBottom(controlButtonPane);
+        sidePane.setBottom(controlButtonPane);
+
         root.setStyle(
             "-fx-background-color: rgba(0, 0, 0, 1); -fx-background-radius: 8px; -fx-border-radius: 8px; -fx-border-width: 5px; -fx-border-color: rgba(60, 63, 65, 0.7); -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.8), 10, 0, 0, 0);");
     }


### PR DESCRIPTION
The home and stats buttons should always be accessible at the end of a game, it was due to the fact that it was on the bottom of a borderpane while the left side, containing grid with statistics was sometimes too long for some games, making it diseappear (for exemple, bubble, rabbit games...)